### PR TITLE
Wire interrupts in Carfield

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -126,7 +126,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 9f0234c1a40cd332f2b502cbbb5f98bd242b29ba
+    revision: 3b773c80985294375421c8f8ad57c009c74b3d46
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -136,11 +136,13 @@ packages:
     - axi_llc
     - axi_riscv_atomics
     - axi_vga
+    - clic
     - clint
     - common_cells
     - common_verification
     - cva6
     - idma
+    - irq_router
     - opentitan_peripherals
     - register_interface
     - riscv-dbg
@@ -149,7 +151,7 @@ packages:
     revision: bed98f88761ca86706c36c4c33ac600d88c42373
     version: null
     source:
-      Git: https://github.com/pulp-platform/clic.git
+      Git: https://github.com/pulp-platform/clic
     dependencies:
     - common_cells
     - register_interface
@@ -305,6 +307,15 @@ packages:
     - axi
     - common_cells
     - common_verification
+    - register_interface
+  irq_router:
+    revision: d1d31350b24f3965b3a51e1bc96c71eb34e94db3
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/irq_router
+    dependencies:
+    - axi
+    - common_cells
     - register_interface
   l2_tcdm_hybrid_interco:
     revision: fa55e72859dcfb117a2788a77352193bef94ff2b

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   rev: 2bb08879bc2ceabe2b6a0dc283753048a739e27b } # branch: main until newer version tag later than v0.4.0
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.9                        } # overridden in Bender.local to use axi-rt feature
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 9f0234c1a40cd332f2b502cbbb5f98bd242b29ba } # branch: main
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 3b773c80985294375421c8f8ad57c009c74b3d46 } # branch: aottaviano/cva6-clic
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 2adb7271438cdb96c19fbaf3e2a6bf89ffeee568 } # branch: lv/phys_in_use
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 08503a05307ef556ed5439619c70c039ff93d77a } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 60e768a3ef29f47339e31674d497293f5a768893 } # branch: atops

--- a/carfield.mk
+++ b/carfield.mk
@@ -17,6 +17,13 @@ TBENCH   ?= tb_carfield_soc
 BOOTMODE ?= 0 # default passive bootmode
 PRELMODE ?= 1 # default serial link preload
 VOPTARGS ?=
+# Interrupt configuration in cheshire
+# CLINT interruptible harts
+CLINTCORES     := 3
+# PLIC interruptible harts
+PLICCORES      := 6
+# PLIC number of input interrupts
+PLIC_NUM_INTRS := 128
 
 # Include cheshire's makefrag only if the dependency was cloned
 -include $(CHS_ROOT)/cheshire.mk
@@ -99,6 +106,18 @@ hw/regs/carfield_reg_pkg.sv hw/regs/carfield_reg_top.sv: hw/regs/carfield_regs.h
 ## checked-in pregenerated register file RTL should be up-to-date. If you regenerate the regfile, do
 ## not forget to check in the generated RTL.
 regenerate_soc_regs: hw/regs/carfield_reg_pkg.sv hw/regs/carfield_reg_top.sv
+
+## @section Carfield CLINT and PLIC interruptible harts configuration
+
+## The default configuration in cheshire allows for one interruptible hart. When the number of
+## external interruptible harts is updated in the cheshire cfg (cheshire_pkg.sv), we need to
+## regenerate the PLIC and CLINT accordingly.
+## CLINT: define CLINTCORES used in cheshire.mk before including the makefrag.
+## PLIC: edit the hjson configuration file in cheshire.
+.PHONY: update_plic
+update_plic: $(CHS_ROOT)/hw/rv_plic.cfg.hjson
+	sed -i 's/src: .*/src: $(PLIC_NUM_INTRS),/' $<
+	sed -i 's/target: .*/target: $(PLICCORES),/' $<
 
 $(CAR_ROOT)/tb/hyp_vip:
 	rm -rf $@

--- a/carfield.mk
+++ b/carfield.mk
@@ -183,7 +183,11 @@ car-checkout-deps:
 .PHONY: car-checkout
 car-checkout: car-checkout-deps
 
+## @section Carfield initialization
 .PHONY: car-hw-init
+## Initialize carfield by generating cheshire and spatz registers and wrapper, respectively
+## This step takes care of the generation of the missing hardware, or an update of the configuration
+## of some IPs, such as the PLIC or CLINT.
 car-hw-init: spatz-hw-init chs-hw-init
 
 .PHONY: spatz-hw-init
@@ -191,22 +195,29 @@ spatz-hw-init:
 	$(MAKE) -C $(SPATZ_MAKEDIR) -B SPATZ_CLUSTER_CFG=carfield.hjson bootrom
 
 .PHONY: chs-hw-init
-chs-hw-init:
+## This target has a prerequisite, i.e. the PLIC configuration must be chosen before generating the
+## hardware.
+chs-hw-init: update_plic
 	$(MAKE) chs-hw-all
 
 .PHONY: chs-sim-init
+## Downloads verification IPs for SPI and I2C from cheshire and used by Carfield.
 chs-sim-init:
 	$(MAKE) chs-sim-all
 
 .PHONY: chs-sw-build
+## Builds the SW libraries in cheshire and generates an archive (`libcheshire.a`) available for
+## carfield as static library at link time.
 chs-sw-build:
 	$(MAKE) chs-sw-all
 
 .PHONY: car-sw-build
+## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
 car-sw-build: chs-sw-build
 	$(MAKE) car-sw-all
 
 .PHONY: car-init
+## Shortcut to initialize carfield with all the targets described above.
 car-init: car-checkout car-hw-init car-sim-init car-sw-build
 
 ############

--- a/hw/cheshire_wrap.sv
+++ b/hw/cheshire_wrap.sv
@@ -17,6 +17,7 @@ module cheshire_wrap
 #(
   parameter cheshire_cfg_t Cfg = '0,
   parameter dm::hartinfo_t [iomsb(Cfg.NumExtDbgHarts)-1:0] ExtHartinfo = '0,
+  parameter int unsigned NumExtIntrs            = 32,
   parameter type cheshire_axi_ext_llc_ar_chan_t = logic,
   parameter type cheshire_axi_ext_llc_aw_chan_t = logic,
   parameter type cheshire_axi_ext_llc_b_chan_t  = logic,
@@ -262,12 +263,13 @@ module cheshire_wrap
   output logic                  [1:0] ext_reg_async_slv_ack_o,
   input  cheshire_reg_ext_rsp_t [1:0] ext_reg_async_slv_data_i,
   // Interrupts from external devices
-  input  logic [iomsb(Cfg.NumExtIntrs):0] intr_ext_i,
+  input  logic [iomsb(NumExtIntrs):0] intr_ext_i,
   // Interrupts to external harts
   output logic [iomsb(Cfg.NumExtIrqHarts):0] meip_ext_o,
   output logic [iomsb(Cfg.NumExtIrqHarts):0] seip_ext_o,
   output logic [iomsb(Cfg.NumExtIrqHarts):0] mtip_ext_o,
   output logic [iomsb(Cfg.NumExtIrqHarts):0] msip_ext_o,
+  output logic [iomsb(Cfg.NumExtRouterTargets*(NumExtIntrs+NumIntIntrs)):0] intr_distributed_o,
   // Debug interface to external harts
   output logic                               dbg_active_o,
   output logic [iomsb(Cfg.NumExtDbgHarts):0] dbg_ext_req_o,
@@ -352,6 +354,7 @@ end
 cheshire_soc #(
   .Cfg               ( Cfg                        ),
   .ExtHartinfo       ( '0                         ),
+  .NumExtIntrs       ( NumExtIntrs                ),
   .axi_ext_llc_req_t ( cheshire_axi_ext_llc_req_t ),
   .axi_ext_llc_rsp_t ( cheshire_axi_ext_llc_rsp_t ),
   .axi_ext_mst_req_t ( cheshire_axi_ext_mst_req_t ),
@@ -384,6 +387,7 @@ cheshire_soc #(
   .seip_ext_o,
   .mtip_ext_o,
   .msip_ext_o,
+  .intr_distributed_o,
   // Debug interface to external harts
   .dbg_active_o     ,
   .dbg_ext_req_o    ,


### PR DESCRIPTION
- [x] Wire interrupts in the SoC according to:

![carfield_interrupts](https://user-images.githubusercontent.com/62642743/232686585-cba2d10b-a696-47ae-b6df-16f0d5269b3c.png)

Most updates have been performed in [cheshire](https://github.com/pulp-platform/cheshire), PR#31. It can be found at [this link](https://github.com/pulp-platform/cheshire/pull/31).

- [x] Synchronize edge-triggered interrupts crossing clock domains with dual-clock edge propagator