### PR TITLE
Fix RTL against Spyglass and Synthesis (elaboration)

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: SHL-0.51
 
 overrides:
-  axi               : { git: https://github.com/pulp-platform/axi.git                 , version: =0.39.0-beta.4                         }
-  apb:                { git: "https://github.com/pulp-platform/apb.git"               , version: =0.2.3                                 }
-  register_interface: { git: "https://github.com/pulp-platform/register_interface.git", rev: 7786760a75fed8534c84f6e52e80089e2d491b76   } # branch: master
-  redundancy_cells:   { git: "https://github.com/pulp-platform/redundancy_cells.git"  , rev: "d44b90c3d5c6ed228bbc07cac7a8276e361272ee" } # branch: fix_ecc_wrap
-  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.11                                }
-  riscv-dbg:          { git: "https://github.com/pulp-platform/riscv-dbg.git"         , version: =0.8.0                                 }
-  common_cells:       { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.29.0                                 }
-  idma:               { git: "https://github.com/pulp-platform/idma.git"              , rev:     437ffa9                                }
-  hier-icache:        { git: "https://github.com/pulp-platform/hier-icache.git"       , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
-  scm:                { git: "https://github.com/pulp-platform/scm.git"               , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }
+  axi:                  { git: https://github.com/pulp-platform/axi.git                 , version: =0.39.0-beta.8                         }
+  apb:                  { git: "https://github.com/pulp-platform/apb.git"               , version: =0.2.3                                 }
+  register_interface:   { git: "https://github.com/pulp-platform/register_interface.git", rev: 46c5ad30fa6e1906a94718c9b7ed9e434badcf5d   } # branch: yt/timin-loop
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"  , rev: "d44b90c3d5c6ed228bbc07cac7a8276e361272ee" } # branch: fix_ecc_wrap
+  tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.11                                }
+  riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"         , version: =0.8.0                                 }
+  common_cells:         { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.29.0                                 }
+  idma:                 { git: "https://github.com/pulp-platform/idma.git"              , rev:     437ffa9                                }
+  hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"       , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
+  scm:                  { git: "https://github.com/pulp-platform/scm.git"               , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }
+  cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix

--- a/Bender.local
+++ b/Bender.local
@@ -11,3 +11,5 @@ overrides:
   riscv-dbg:          { git: "https://github.com/pulp-platform/riscv-dbg.git"         , version: =0.8.0                                 }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.29.0                                 }
   idma:               { git: "https://github.com/pulp-platform/idma.git"              , rev:     437ffa9                                }
+  hier-icache:        { git: "https://github.com/pulp-platform/hier-icache.git"       , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
+  scm:                { git: "https://github.com/pulp-platform/scm.git"               , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }

--- a/Bender.lock
+++ b/Bender.lock
@@ -22,8 +22,8 @@ packages:
     - apb
     - register_interface
   axi:
-    revision: fd60be8b51a4fa7476856be162ce3334474592ba
-    version: 0.39.0-beta.4
+    revision: 56533cbbdf9ea41ab1daaa164595faae3d7ace5a
+    version: 0.39.0-beta.8
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -144,8 +144,8 @@ packages:
     - common_cells
     - register_interface
   cluster_interconnect:
-    revision: 7d0a4f8acae71a583a6713cab5554e60b9bb8d27
-    version: 1.2.1
+    revision: 89e1019d64a86425211be6200770576cbdf3e8b3
+    version: null
     source:
       Git: https://github.com/pulp-platform/cluster_interconnect.git
     dependencies:
@@ -313,8 +313,8 @@ packages:
     - common_cells
     - register_interface
   mchan:
-    revision: a9c71f2d9845a4ca05cf2c6ad089b4753f76fc2e
-    version: 1.2.3
+    revision: 7f064f205a3e0203e959b14773c4afecf56681ab
+    version: null
     source:
       Git: https://github.com/pulp-platform/mchan.git
     dependencies:
@@ -327,7 +327,7 @@ packages:
     dependencies:
     - common_cells
   opentitan:
-    revision: c4a1b1d9bca7ca443a64b9f7f5586afa7a28cc5f
+    revision: 969841978a293f6d7e890557257621c17f4eb44b
     version: null
     source:
       Git: https://github.com/alsaqr-platform/opentitan.git
@@ -350,7 +350,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 2376e7d79e77a32863ff845275857a8694f7e225
+    revision: 91ec9e6539e6e6a118756eeba73cb5013b15288f
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -369,8 +369,10 @@ packages:
     - hier-icache
     - hwpe-datamover-example
     - ibex
+    - idma
     - mchan
     - per2axi
+    - register_interface
     - scm
     - tech_cells_generic
     - timer_unit
@@ -385,7 +387,7 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: 7786760a75fed8534c84f6e52e80089e2d491b76
+    revision: 46c5ad30fa6e1906a94718c9b7ed9e434badcf5d
     version: null
     source:
       Git: https://github.com/pulp-platform/register_interface.git
@@ -393,6 +395,7 @@ packages:
     - apb
     - axi
     - common_cells
+    - common_verification
   riscv-dbg:
     revision: 138d74bcaa90c70180c12215db3776813d2a95f2
     version: 0.8.0

--- a/Bender.lock
+++ b/Bender.lock
@@ -56,6 +56,14 @@ packages:
     - common_verification
     - register_interface
     - tech_cells_generic
+  axi_node:
+    revision: e2d038004c5b8cec9dd3bb9d23ad0bee72f9d908
+    version: 1.1.4
+    source:
+      Git: git@github.com:pulp-platform/axi_node.git
+    dependencies:
+    - axi
+    - common_cells
   axi_riscv_atomics:
     revision: 97dcb14ef057cbe5bd70dda2060b5bb9e7e04c6d
     version: 0.7.0
@@ -222,12 +230,12 @@ packages:
     - hwpe-stream
     - l2_tcdm_hybrid_interco
   hier-icache:
-    revision: 9e53e957f7e0fd88616a5f3fbcc2617fbc3c9d0d
+    revision: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be
     version: null
     source:
       Git: https://github.com/pulp-platform/hier-icache.git
     dependencies:
-    - axi
+    - axi_node
     - axi_slice
     - common_cells
     - icache-intc
@@ -277,7 +285,7 @@ packages:
     revision: 663c3b6d3c2bf63ff25cda46f33c799c647b3985
     version: 1.0.1
     source:
-      Git: https://github.com/pulp-platform/icache-intc.git
+      Git: git@github.com:pulp-platform/icache-intc.git
     dependencies: []
   idma:
     revision: 437ffa9dac5dea0daccfd3e8ae604d4f6ae2cdf1
@@ -413,11 +421,12 @@ packages:
     - tech_cells_generic
     - timer_unit
   scm:
-    revision: 998466d2a3c2d7d572e43d2666d93c4f767d8d60
-    version: 1.1.1
+    revision: f7b51416f3c407e4c31e9c016616d57aae2687bd
+    version: null
     source:
       Git: https://github.com/pulp-platform/scm.git
-    dependencies: []
+    dependencies:
+    - tech_cells_generic
   serial_link:
     revision: f79be97dbd96707b822dd6c2ed7ca87b54bd4378
     version: 1.0.1

--- a/Bender.yml
+++ b/Bender.yml
@@ -8,14 +8,14 @@ package:
     - "Luca Valente <luca.valente@unibo.it>"
 
 dependencies:
-  register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: =0.3.8                               }
+  register_interface: { git: "https://github.com/pulp-platform/register_interface.git", rev: 46c5ad30fa6e1906a94718c9b7ed9e434badcf5d } # branch: yt/timin-loop
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: =0.39.0-beta.4                       }
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: b8a9bb133355a1c19bd81d00e58f77c4dc6e8ceb } # branch: main
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 80f137ce8904c78602b589918911f388d507e935 }
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 505c35a8df7f042fc8fc07c5dc40bc6412f7b27d } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 0c5c15dac99a5cf554102d1c579a8c9c768b5207 } # branch: master
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 2376e7d79e77a32863ff845275857a8694f7e225 } # branch: yt/carfield-integration
-  opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: c4a1b1d9bca7ca443a64b9f7f5586afa7a28cc5f } # branch: lowRISC-rebase
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 91ec9e6539e6e6a118756eeba73cb5013b15288f } # branch: yt/carfield-integration
+  opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 969841978a293f6d7e890557257621c17f4eb44b } # branch: lowRISC-rebase
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             rev: ce0cb2e7fe48a00fd2ee8b39f675e6c33a5a31d2 } # branch: aottaviano/mailbox-old
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -46,4 +46,7 @@ sources:
       - tb/hyp_vip/s27ks0641.v
       - tb/carfield_fix.sv
       - tb/carfield_tb.sv
-  
+
+  - target: spyglass
+    files:
+      - scripts/spyglass/src/carfield_wrap.sv

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VOPTARGS ?=
 # Include cheshire's makefrag only if the dependency was cloned
 -include $(CHS_ROOT)/cheshire.mk
 
-# Spatz 
+# Spatz
 SPATZ_ROOT ?= $(ROOT)/spatz
 SPATZ_MAKEDIR := $(SPATZ_ROOT)/hw/system/spatz_cluster
 
@@ -29,22 +29,23 @@ MEMTYPE  ?= spm
 BINARY   ?= $(CHS_ROOT)/sw/tests/$(TESTNAME).$(MEMTYPE).elf
 IMAGE    ?=
 
+# Include bender targets and defines for common usage and synth verification
+# (the following includes are mandatory)
+include bender-common.mk
+include bender-synth.mk
+
 # bender targets
 TARGETS += -t sim
-TARGETS += -t rtl
-TARGETS += -t cv64a6_imafdcsclic_sv39
 TARGETS += -t test
-TARGETS += -t cva6
 TARGETS += -t integer_cluster
 TARGETS += -t cv32e40p_use_ff_regfile
+TARGETS += -t cv64a6_imafdcsclic_sv39
 TARGETS += -t spatz
 TARGETS += -t simulation
+TARGETS += $(common_targs)
 
 # bender defines
-DEFINES += -D FEATURE_ICACHE_STAT
-DEFINES += -D PRIVATE_ICACHE
-DEFINES += -D HIERARCHY_ICACHE_32BIT
-DEFINES += -D TARGET_SPATZ
+DEFINES += $(common_defs)
 
 ifdef gui
 	VSIM_FLAG :=
@@ -59,13 +60,14 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 6c22cff5b6cde5a7d83a5c1b474c8d35d37fd81c
+CAR_NONFREE_COMMIT ?= 6a8cb8ab9382a8722d2f2ef6d85fd6b2865e7fff
 
 car-nonfree-init:
 	git clone $(CAR_NONFREE_REMOTE) nonfree
 	cd nonfree && git checkout $(CAR_NONFREE_COMMIT)
 
 -include nonfree/nonfree.mk
+-include scripts/spy.mk
 
 ############
 # Build SW #
@@ -105,3 +107,14 @@ chs-init:
 	$(MAKE) -B chs-hw-all
 	$(MAKE) -B chs-sim-all
 	$(MAKE) -B chs-sw-all
+
+############
+# RTL LINT #
+############
+SPYGLASS_TARGS += $(common_targs)
+SPYGLASS_TARGS += $(synth_targs)
+SPYGLASS_DEFS += $(common_defs)
+SPYGLASS_DEFS += $(synth_defs)
+
+lint:
+	$(MAKE) -C scripts lint bender_defs="$(SPYGLASS_DEFS)" bender_targs="$(SPYGLASS_TARGS)" > make.log

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,9 @@ include bender-synth.mk
 # bender targets
 TARGETS += -t sim
 TARGETS += -t test
+TARGETS += -t rtl
 TARGETS += -t integer_cluster
-TARGETS += -t cv32e40p_use_ff_regfile
 TARGETS += -t cv64a6_imafdcsclic_sv39
-TARGETS += -t spatz
 TARGETS += -t simulation
 TARGETS += $(common_targs)
 
@@ -60,7 +59,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 6a8cb8ab9382a8722d2f2ef6d85fd6b2865e7fff
+CAR_NONFREE_COMMIT ?= 2ad3817a7b84608c8c63485ccd6dcaff0d2a2792
 
 car-nonfree-init:
 	git clone $(CAR_NONFREE_REMOTE) nonfree
@@ -78,6 +77,7 @@ include $(CAR_SW_DIR)/sw.mk
 ##############
 # Simulation #
 ##############
+.PHONY: scripts/carfield_compile.tcl
 
 tb/hyp_vip:
 	git clone git@iis-git.ee.ethz.ch:carfield/hyp_vip.git $@

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -6,11 +6,12 @@
 # Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 # bender targets
-common_targs += -t rtl
 common_targs += -t cva6
+common_targs += -t mchan
+common_targs += -t spatz
+common_targs += -t cv32e40p_use_ff_regfile
 
 # bender defines
 common_defs += -D FEATURE_ICACHE_STAT
 common_defs += -D PRIVATE_ICACHE
 common_defs += -D HIERARCHY_ICACHE_32BIT
-common_defs += -D TARGET_SPATZ

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -1,0 +1,16 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Yvan Tortorella <yvan.tortorella@unibo.it>
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+# bender targets
+common_targs += -t rtl
+common_targs += -t cva6
+
+# bender defines
+common_defs += -D FEATURE_ICACHE_STAT
+common_defs += -D PRIVATE_ICACHE
+common_defs += -D HIERARCHY_ICACHE_32BIT
+common_defs += -D TARGET_SPATZ

--- a/bender-synth.mk
+++ b/bender-synth.mk
@@ -7,8 +7,6 @@
 
 # bender targets
 synth_targs += -t asic
-synth_targs += -t spyglass
-synth_targs += -t cva6_test
 synth_targs += -t synthesis
 synth_targs += -t top_level
 synth_targs += -t intel16
@@ -17,6 +15,5 @@ synth_targs += -t cluster_standalone
 synth_targs += -t cv64a6_imafdc_sv39
 
 # bender defines
-synth_defs += -D SPYGLASS
 synth_defs += -D SYNTHESIS
 synth_defs += -D EXCLUDE_PADFRAME

--- a/bender-synth.mk
+++ b/bender-synth.mk
@@ -1,0 +1,22 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Yvan Tortorella <yvan.tortorella@unibo.it>
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+# bender targets
+synth_targs += -t asic
+synth_targs += -t spyglass
+synth_targs += -t cva6_test
+synth_targs += -t synthesis
+synth_targs += -t top_level
+synth_targs += -t intel16
+synth_targs += -t scm_use_latch_scm
+synth_targs += -t cluster_standalone
+synth_targs += -t cv64a6_imafdc_sv39
+
+# bender defines
+synth_defs += -D SPYGLASS
+synth_defs += -D SYNTHESIS
+synth_defs += -D EXCLUDE_PADFRAME

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -241,6 +241,7 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
 /**********************/
 localparam int unsigned AxiNarrowAddrWidth = 32;
 localparam int unsigned AxiNarrowDataWidth = 32;
+localparam int unsigned AxiNarrowStrobe    = AxiNarrowDataWidth/8;
 
 /*****************/
 /* L2 Parameters */

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -8,12 +8,10 @@ ROOT        := $(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST))/../
 
 SNPS_SG     ?= spyglass-2022.06
 
-bender_defs  ?= -D SPYGLASS        \
-                -D SYNTHESIS       \
+bender_defs  ?= -D SYNTHESIS       \
                 -D EXCLUDE_PADFRAME
 
 bender_targs ?= -t asic               \
-                -t spyglass           \
                 -t cva6_test          \
                 -t synthesis          \
                 -t top_level          \
@@ -30,7 +28,7 @@ lint: update gen_script spyglass/sgdc/func.sgdc spyglass/scripts/run_lint.tcl
 
 gen_script: update
 	mkdir -p spyglass/tmp
-	bender script verilator $(bender_targs) $(bender_defs) > spyglass/tmp/files
+	bender script verilator -t spyglass $(bender_targs) -D SPYGLASS $(bender_defs) > spyglass/tmp/files
 
 update:
 	bender update

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+ROOT        := $(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST))/../)))
+
+SNPS_SG     ?= spyglass-2022.06
+
+bender_defs  ?= -D SPYGLASS        \
+                -D SYNTHESIS       \
+                -D EXCLUDE_PADFRAME
+
+bender_targs ?= -t asic               \
+                -t spyglass           \
+                -t cva6_test          \
+                -t synthesis          \
+                -t top_level          \
+                -t intel16            \
+                -t scm_use_latch_scm  \
+                -t cluster_standalone \
+                -t cv64a6_imafdc_sv39
+
+# PHONY since these targets are all pretty fast compared to spyglass
+.PHONY: lint gen_script update
+
+lint: update gen_script spyglass/sgdc/func.sgdc spyglass/scripts/run_lint.tcl
+	cd spyglass; $(SNPS_SG) sg_shell -tcl scripts/run_lint.tcl
+
+gen_script: update
+	mkdir -p spyglass/tmp
+	bender script verilator $(bender_targs) $(bender_defs) > spyglass/tmp/files
+
+update:
+	bender update
+	make -C $(ROOT) chs-hw-all
+	make -C $(ROOT) spatz-init

--- a/scripts/spyglass/scripts/run_lint.tcl
+++ b/scripts/spyglass/scripts/run_lint.tcl
@@ -1,0 +1,45 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+set PROJECT   carfield
+set TIMESTAMP [exec date +%Y%m%d_%H%M%S]
+
+# Add ignored files to this list
+set IgnoredFiles [list [exec bender path cva6]/core/include/axi_intf.sv]
+
+new_project sg_projects/${PROJECT}_${TIMESTAMP}
+current_methodology $env(SPYGLASS_HOME)/GuideWare/latest/block/rtl_handoff
+
+# Ignore re-defined files
+foreach file $IgnoredFiles {
+  set_option ignorefile $file
+}
+
+# Read the RTL
+read_file -type sourcelist tmp/files
+
+# Read constraints
+read_file -type sgdc sgdc/func.sgdc
+
+# Set options
+set_option enableSV12 yes
+set_option language_mode mixed
+set_option designread_disable_flatten no
+set_option mthresh 32768
+set_option top carfield_wrap
+
+# Link Design
+current_design carfield_wrap
+compile_design
+
+# Set lint_rtl goal and run
+current_goal lint/lint_rtl
+run_goal
+
+# Create a link to the results
+exec rm -rf sg_projects/${PROJECT}
+exec ln -sf ${PROJECT}_${TIMESTAMP} sg_projects/${PROJECT}
+
+# Ciao!
+exit -save

--- a/scripts/spyglass/sgdc/func.sgdc
+++ b/scripts/spyglass/sgdc/func.sgdc
@@ -1,0 +1,11 @@
+# Copyright 2022 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+current_design carfield_wrap
+test_mode -name "carfield_wrap.test_mode_i" -value "1"
+reset -name "rst_ni" -async -value 0
+reset -name "jtag_trst_ni" -async -value 0
+clock -name "clk_i" -tag sys_clk -domain sys_clk_domain
+clock -name "jtag_tck_i" -tag jtag_clk -domain jtag_clk_domain
+clock -name "rtc_i" -tag rt_clk -domain rt_clk_domain

--- a/scripts/spyglass/src/carfield_wrap.sv
+++ b/scripts/spyglass/src/carfield_wrap.sv
@@ -1,0 +1,137 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// Description: Carfield wrap for SpyGlass analysis.
+
+module carfield_wrap import carfield_pkg::*; import cheshire_pkg::*; #(
+    parameter cheshire_cfg_t Cfg = carfield_pkg::CarfieldCfgDefault, // from Cheshire package
+    parameter int unsigned HypNumPhys  = 1,
+    parameter int unsigned HypNumChips = 1
+) (
+    input   logic                                       clk_i,
+    input   logic                                       rst_ni,
+    input   logic                                       test_mode_i,
+    // Boot mode selection
+    input   logic [1:0]                                 boot_mode_i,
+    // CLINT
+    input   logic                                       rtc_i,
+    // JTAG Interfacex
+    input   logic                                       jtag_tck_i,
+    input   logic                                       jtag_trst_ni,
+    input   logic                                       jtag_tms_i,
+    input   logic                                       jtag_tdi_i,
+    output  logic                                       jtag_tdo_o,
+    output  logic                                       jtag_tdo_oe_o,
+    // UART Interface
+    output logic                                        uart_tx_o,
+    input  logic                                        uart_rx_i,
+    // UART Modem flow control
+    output logic                                        uart_rts_no,
+    output logic                                        uart_dtr_no,
+    input  logic                                        uart_cts_ni,
+    input  logic                                        uart_dsr_ni,
+    input  logic                                        uart_dcd_ni,
+    input  logic                                        uart_rin_ni,
+    // I2C Interface
+    output logic                                        i2c_sda_o,
+    input  logic                                        i2c_sda_i,
+    output logic                                        i2c_sda_en_o,
+    output logic                                        i2c_scl_o,
+    input  logic                                        i2c_scl_i,
+    output logic                                        i2c_scl_en_o,
+    // SPI Host Interface
+    output logic                                        spih_sck_o,
+    output logic                                        spih_sck_en_o,
+    output logic [SpihNumCs-1:0]                        spih_csb_o,
+    output logic [SpihNumCs-1:0]                        spih_csb_en_o,
+    output logic [ 3:0]                                 spih_sd_o,
+    output logic [ 3:0]                                 spih_sd_en_o,
+    input  logic [ 3:0]                                 spih_sd_i,
+    // GPIO interface
+    input  logic [31:0]                                 gpio_i,
+    output logic [31:0]                                 gpio_o,
+    output logic [31:0]                                 gpio_en_o,
+    // Serial link interface
+    input  logic [SlinkNumChan-1:0]                     slink_rcv_clk_i,
+    output logic [SlinkNumChan-1:0]                     slink_rcv_clk_o,
+    input  logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_i,
+    output logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_o,
+    // HyperBus clocks
+    input  logic                                        hyp_clk_phy_i,
+    input  logic                                        hyp_rst_phy_ni,
+    // Physical interace: facing HyperBus
+    inout  [HypNumPhys-1:0][HypNumChips-1:0]            pad_hyper_csn,
+    inout  [HypNumPhys-1:0]                             pad_hyper_ck,
+    inout  [HypNumPhys-1:0]                             pad_hyper_ckn,
+    inout  [HypNumPhys-1:0]                             pad_hyper_rwds,
+    inout  [HypNumPhys-1:0]                             pad_hyper_reset,
+    inout  [HypNumPhys-1:0][7:0]                        pad_hyper_dq
+);
+
+  // DefaultCfg from cheshire_pkg
+  localparam cheshire_cfg_t DutCfg = DefaultCfg;
+
+  /********************/
+  /* Hyper RAM Params */
+  /********************/
+
+  localparam int NumPhys  = 1;
+  localparam int NumChips = 2;
+
+  carfield      #(
+    .Cfg         ( DefaultCfg ),
+    .HypNumPhys  ( NumPhys    ),
+    .HypNumChips ( NumChips   )
+  ) i_dut        (
+    .clk_i           (clk_i            ),
+    .rst_ni          (rst_ni           ),
+    .test_mode_i     (test_mode_i      ),
+    .boot_mode_i     (boot_mode_i      ),
+    .rtc_i           (rtc_i            ),
+    .jtag_tck_i      (jtag_tck_i       ),
+    .jtag_trst_ni    (jtag_trst_ni     ),
+    .jtag_tms_i      (jtag_tms_i       ),
+    .jtag_tdi_i      (jtag_tdi_i       ),
+    .jtag_tdo_o      (jtag_tdo_o       ),
+    .jtag_tdo_oe_o   (jtag_tdo_oe_o    ),
+    .uart_tx_o       (uart_tx_o        ),
+    .uart_rx_i       (uart_rx_i        ),
+    .uart_rts_no     (uart_rts_no      ),
+    .uart_dtr_no     (uart_dtr_no      ),
+    .uart_cts_ni     (uart_cts_ni      ),
+    .uart_dsr_ni     (uart_dsr_ni      ),
+    .uart_dcd_ni     (uart_dcd_ni      ),
+    .uart_rin_ni     (uart_rin_ni      ),
+    .i2c_sda_o       (i2c_sda_o        ),
+    .i2c_sda_i       (i2c_sda_i        ),
+    .i2c_sda_en_o    (i2c_sda_en_o     ),
+    .i2c_scl_o       (i2c_scl_o        ),
+    .i2c_scl_i       (i2c_scl_i        ),
+    .i2c_scl_en_o    (i2c_scl_en_o     ),
+    .spih_sck_o      (spih_sck_o       ),
+    .spih_sck_en_o   (spih_sck_en_o    ),
+    .spih_csb_o      (spih_csb_o       ),
+    .spih_csb_en_o   (spih_csb_en_o    ),
+    .spih_sd_o       (spih_sd_o        ),
+    .spih_sd_en_o    (spih_sd_en_o     ),
+    .spih_sd_i       (spih_sd_i        ),
+    .gpio_i          (gpio_i           ),
+    .gpio_o          (gpio_o           ),
+    .gpio_en_o       (gpio_en_o        ),
+    .slink_rcv_clk_i (slink_rcv_clk_i  ),
+    .slink_rcv_clk_o (slink_rcv_clk_o  ),
+    .slink_i         (slink_i          ),
+    .slink_o         (slink_o          ),
+    .hyp_clk_phy_i   (hyp_clk_phy_i    ),
+    .hyp_rst_phy_ni  (hyp_rst_phy_ni   ),
+    .pad_hyper_csn   (pad_hyper_csn    ),
+    .pad_hyper_ck    (pad_hyper_ck     ),
+    .pad_hyper_ckn   (pad_hyper_ckn    ),
+    .pad_hyper_rwds  (pad_hyper_rwds   ),
+    .pad_hyper_reset (pad_hyper_reset  ),
+    .pad_hyper_dq    (pad_hyper_dq     )
+  );
+
+endmodule


### PR DESCRIPTION
- [x] Implement a SpyGlass flow to lint the RTL and verify that it can be elaborated. The flow is also integrated into the non-free GitLab CI. 

**[Comment @mp-17]** This is a good starting point for elaboration. If we want to extend the checks to the CDCs and add reliability to the design, we have to modify the `.sdc` constraints -> to be addressed in a separate PR.

- [x] Fixes for synthesis flow and elaboration:
* Bump integer cluster pointer (fix `mchan` DMA width mismatches [[1]](https://github.com/pulp-platform/pulp_cluster/commits/yt/carfield-integration))
* Fix `reg_to_tlul` timing loop in register interface [[2]](https://github.com/pulp-platform/register_interface/pull/38))
* Bump Open Titan to solve redefinition of `packages` and `macros`
* Fix Bender targets
* Waive linting for `line-length` check in macro definition, it is not understood by the synthesis tool

