### PR TITLE
Align FPU version for carfield

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bender
 cheshire
+spatz
 modelsim.ini
 scripts/carfield_compile.tcl
 tb/hyp_vip

--- a/Bender.local
+++ b/Bender.local
@@ -10,5 +10,4 @@ overrides:
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.11                                }
   riscv-dbg:          { git: "https://github.com/pulp-platform/riscv-dbg.git"         , version: =0.8.0                                 }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.29.0                                 }
-  fpnew:              { git: "https://github.com/pulp-platform/cvfpu.git"             , rev:     pulp-v0.1.1                            }
   idma:               { git: "https://github.com/pulp-platform/idma.git"              , rev:     437ffa9                                }

--- a/Bender.lock
+++ b/Bender.lock
@@ -100,7 +100,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 0a1258dae530b3bae411ce0ab18cd5b4080f1c7d
+    revision: 634aa5bf0a1826f4cb1401e0f8e7545d8f42ce25
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -121,7 +121,7 @@ packages:
     - serial_link
     - tech_cells_generic
   clic:
-    revision: 8df9c5ae1f4a15b5b777c66cfdf41fd44451ffe3
+    revision: ce0d748f28246c0635b225d9c8beb7b76eac8708
     version: null
     source:
       Git: https://github.com/pulp-platform/clic.git
@@ -165,7 +165,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cv32e40p:
-    revision: b26d1d6c5043bc6c535e23bf61b51313c802e44a
+    revision: f67ee07376845b8b8975f86c831c5d17cffcc5cb
     version: null
     source:
       Git: https://github.com/pulp-platform/cv32e40p.git
@@ -174,7 +174,7 @@ packages:
     - fpnew
     - tech_cells_generic
   cva6:
-    revision: 09752c37f63b073c3c17cbe00ad8b5e7cef53712
+    revision: bf806ffa1385876ab70b28df488fafe7ea573a7f
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6
@@ -206,7 +206,7 @@ packages:
     dependencies:
     - common_cells
   fpu_interco:
-    revision: 250b376bb68bd3b4b13c5b8f5ac2155e32152733
+    revision: 7a7899bfee33fcfe9d6166bd3d305cd1fb7118fc
     version: null
     source:
       Git: https://github.com/pulp-platform/fpu_interco.git
@@ -343,7 +343,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 3eb5ed955d6bf1d47f657669351f0cc45436a75b
+    revision: 2376e7d79e77a32863ff845275857a8694f7e225
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -395,7 +395,7 @@ packages:
     - common_cells
     - tech_cells_generic
   safety_island:
-    revision: 76c2f98f59b120be03ada8928ca178e573c155e4
+    revision: 0c5c15dac99a5cf554102d1c579a8c9c768b5207
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:carfield/safety-island.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,11 +10,11 @@ package:
 dependencies:
   register_interface: { git: "https://github.com/pulp-platform/register_interface.git", version: =0.3.8                               }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: =0.39.0-beta.4                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 0a1258dae530b3bae411ce0ab18cd5b4080f1c7d } # branch: sm/fp_cluster
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 634aa5bf0a1826f4cb1401e0f8e7545d8f42ce25 } # branch: sm/fp_cluster
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 80f137ce8904c78602b589918911f388d507e935 }
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 505c35a8df7f042fc8fc07c5dc40bc6412f7b27d } # branch: main
-  safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 76c2f98f59b120be03ada8928ca178e573c155e4 } # branch: master
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 3eb5ed955d6bf1d47f657669351f0cc45436a75b } # branch: yt/carfield-integration
+  safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 0c5c15dac99a5cf554102d1c579a8c9c768b5207 } # branch: master
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 2376e7d79e77a32863ff845275857a8694f7e225 } # branch: yt/carfield-integration
   opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: c4a1b1d9bca7ca443a64b9f7f5586afa7a28cc5f } # branch: lowRISC-rebase
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             rev: ce0cb2e7fe48a00fd2ee8b39f675e6c33a5a31d2 } # branch: aottaviano/mailbox-old
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }


### PR DESCRIPTION
Reference FPU version: [pulp-v0.1.1](https://github.com/pulp-platform/cvfpu/releases/tag/pulp-v0.1.1)

* Alignment required for:

- [x] Safety Island (CV32)
- [x] Integer cluster (to avoid Bender conflicts, FPU is not instantiated in the Integer cluster) -> use same version of CV32
- [x] FP cluster
- [x] Cheshire (CVA6)

* Once aligned:
- [x] Remove `fpu` entry from `Bender.local`