### PR TITLE
Fix Safety Island's power on reset connection and eliding Spyglass.

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -6,7 +6,7 @@ overrides:
   axi:                  { git: https://github.com/pulp-platform/axi.git                 , version: =0.39.0-beta.8                         }
   apb:                  { git: "https://github.com/pulp-platform/apb.git"               , version: =0.2.3                                 }
   register_interface:   { git: "https://github.com/pulp-platform/register_interface.git", rev: 46c5ad30fa6e1906a94718c9b7ed9e434badcf5d   } # branch: yt/timin-loop
-  redundancy_cells:   { git: "https://github.com/pulp-platform/redundancy_cells.git"  , rev: "6e10650b50c7b40f7f81602acf61526330c4d69d" } # branch: michaero/hmr-alt
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"  , rev: "6e10650b50c7b40f7f81602acf61526330c4d69d" } # branch: michaero/hmr-alt
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: =0.2.11                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"         , version: =0.8.0                                 }
   common_cells:         { git: "https://github.com/pulp-platform/common_cells.git"      , version: 1.29.0                                 }
@@ -14,3 +14,4 @@ overrides:
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"       , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
   scm:                  { git: "https://github.com/pulp-platform/scm.git"               , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
+  bus_err_unit:         { git: "git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git"       , rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 }

--- a/Bender.local
+++ b/Bender.local
@@ -14,4 +14,3 @@ overrides:
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"       , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
   scm:                  { git: "https://github.com/pulp-platform/scm.git"               , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3 } # branch: assertion-fix
-  bus_err_unit:         { git: "git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git"       , rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -68,7 +68,7 @@ packages:
     revision: 97dcb14ef057cbe5bd70dda2060b5bb9e7e04c6d
     version: 0.7.0
     source:
-      Git: https://github.com/pulp-platform/axi_riscv_atomics
+      Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:
     - axi
     - common_cells
@@ -90,7 +90,7 @@ packages:
     - common_cells
     - register_interface
   bus_err_unit:
-    revision: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2
+    revision: ff19129ed69094422243a76ae71eef45aa6f2c4b
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git
@@ -177,7 +177,7 @@ packages:
     revision: 9c07fa860593b2caabd9b5681740c25fac04b878
     version: 0.2.3
     source:
-      Git: https://github.com/pulp-platform/common_verification
+      Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cv32e40p:
     revision: 9b77611a1d0c681f4819798d95422b0b895528a2

--- a/Bender.lock
+++ b/Bender.lock
@@ -68,7 +68,7 @@ packages:
     revision: 97dcb14ef057cbe5bd70dda2060b5bb9e7e04c6d
     version: 0.7.0
     source:
-      Git: https://github.com/pulp-platform/axi_riscv_atomics.git
+      Git: https://github.com/pulp-platform/axi_riscv_atomics
     dependencies:
     - axi
     - common_cells
@@ -90,7 +90,7 @@ packages:
     - common_cells
     - register_interface
   bus_err_unit:
-    revision: ff19129ed69094422243a76ae71eef45aa6f2c4b
+    revision: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git
@@ -177,7 +177,7 @@ packages:
     revision: 9c07fa860593b2caabd9b5681740c25fac04b878
     version: 0.2.3
     source:
-      Git: https://github.com/pulp-platform/common_verification.git
+      Git: https://github.com/pulp-platform/common_verification
     dependencies: []
   cv32e40p:
     revision: 9b77611a1d0c681f4819798d95422b0b895528a2
@@ -221,7 +221,7 @@ packages:
     dependencies:
     - common_cells
   fpu_interco:
-    revision: 7a7899bfee33fcfe9d6166bd3d305cd1fb7118fc
+    revision: 2c11ff8176a8b176f2bdd3fc019db2b7db44debf
     version: null
     source:
       Git: https://github.com/pulp-platform/fpu_interco.git
@@ -359,7 +359,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 91ec9e6539e6e6a118756eeba73cb5013b15288f
+    revision: 2fe929632a95e27ebb3f135603835adb60b41fd2
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,6 @@ dependencies:
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
   spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: fe6af882359be12b3884b9c9a5755a022bb031ff } # branch: main
-  bus_err_unit:       { git: "git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git",        rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 }
 
 workspace:
   package_links:

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 80f137ce8904c78602b589918911f388d507e935 }
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 505c35a8df7f042fc8fc07c5dc40bc6412f7b27d } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: c03f1d0b7aad5725010f247130e5d13b36c89c04 } # branch: master
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 91ec9e6539e6e6a118756eeba73cb5013b15288f } # branch: yt/carfield-integration
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 2fe929632a95e27ebb3f135603835adb60b41fd2 } # branch: yt/carfield-integration
   opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 567ae56d23633e2d9738f68ddfdd9b529c87d859 } # branch: lowRISC-rebase
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             rev: ce0cb2e7fe48a00fd2ee8b39f675e6c33a5a31d2 } # branch: aottaviano/mailbox-old
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
@@ -22,6 +22,7 @@ dependencies:
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
   spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: fe6af882359be12b3884b9c9a5755a022bb031ff } # branch: main
+  bus_err_unit:       { git: "git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git",        rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 }
 
 workspace:
   package_links:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 1f7dbbaa324f9f109d81df1db39993e454c4badd
+CAR_NONFREE_COMMIT ?= a5351b2b161e896592b596492bff1abfac367aca
 
 car-nonfree-init:
 	git clone $(CAR_NONFREE_REMOTE) nonfree

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 2ad3817a7b84608c8c63485ccd6dcaff0d2a2792
+CAR_NONFREE_COMMIT ?= 1f7dbbaa324f9f109d81df1db39993e454c4badd
 
 car-nonfree-init:
 	git clone $(CAR_NONFREE_REMOTE) nonfree

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -762,6 +762,7 @@ safety_island_synth_wrapper #(
   .clk_i                  ( clk_i                                    ),
   .ref_clk_i              ( clk_i                                    ),
   .rst_ni                 ( rst_ni                                   ),
+  .pwr_on_rst_ni          ( rst_ni                                   ),
   .test_enable_i          ( '0                                       ),
   .bootmode_i             ( safety_island_bootmode                   ),
   .fetch_en_i             ( '0                                       ), // To SoC Bus


### PR DESCRIPTION
* Connecting Safety Island's  `pwr_on_rst_ni` temporarily to global reset.
* Updating non-free commit to elide spyglass since we cannot reliably use it.