### PR TITLE
Add support for RISC-V atomics to shared L2 Mem 

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ dependencies:
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: =0.39.0-beta.4                       }
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: b8a9bb133355a1c19bd81d00e58f77c4dc6e8ceb } # branch: main
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 80f137ce8904c78602b589918911f388d507e935 }
-  car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 505c35a8df7f042fc8fc07c5dc40bc6412f7b27d } # branch: main
+  car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 545435800fc5f3451a9f8ebf07e2bd5337714fe4 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: c03f1d0b7aad5725010f247130e5d13b36c89c04 } # branch: master
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 2fe929632a95e27ebb3f135603835adb60b41fd2 } # branch: yt/carfield-integration
   opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 567ae56d23633e2d9738f68ddfdd9b529c87d859 } # branch: lowRISC-rebase


### PR DESCRIPTION
In the latest L2, I add support for riscv_atomics, and I expose extra parameters to config the rsicv_atomic_module. 
They are in default value with Cheshire, which is fine for now.
It would be good to put values in these parameters on the top level, which align with future changes