### PR TITLE
Add power-on reset and mailbox interrupt to integer cluster

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -177,7 +177,7 @@ packages:
     revision: 9c07fa860593b2caabd9b5681740c25fac04b878
     version: 0.2.3
     source:
-      Git: https://github.com/pulp-platform/common_verification
+      Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cv32e40p:
     revision: 9b77611a1d0c681f4819798d95422b0b895528a2
@@ -359,7 +359,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 56d64633432a72de8da49c1f0418500a9c173ddb
+    revision: 43bb73f5f239b6d9bade79ef4b5c62756bd58dc4
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 80f137ce8904c78602b589918911f388d507e935 }
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 505c35a8df7f042fc8fc07c5dc40bc6412f7b27d } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: c03f1d0b7aad5725010f247130e5d13b36c89c04 } # branch: master
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 56d64633432a72de8da49c1f0418500a9c173ddb } # branch: yt/carfield-integration
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 43bb73f5f239b6d9bade79ef4b5c62756bd58dc4 } # branch: yt/carfield-integration
   opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 567ae56d23633e2d9738f68ddfdd9b529c87d859 } # branch: lowRISC-rebase
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             rev: ce0cb2e7fe48a00fd2ee8b39f675e6c33a5a31d2 } # branch: aottaviano/mailbox-old
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -852,6 +852,7 @@ pulp_cluster #(
 ) i_integer_cluster            (
   .clk_i                       ( clk_i                                  ),
   .rst_ni                      ( rst_ni                                 ),
+  .pwr_on_rst_ni               ( rst_ni                                 ),
   .ref_clk_i                   ( clk_i                                  ),
   .pmu_mem_pwdn_i              ( '0                                     ),
   .base_addr_i                 ( '0                                     ),
@@ -868,6 +869,7 @@ pulp_cluster #(
   .dma_pe_irq_ack_i            ( '1                                     ), // To edge propagator (?)
   .dma_pe_irq_valid_o          (                                        ), // To edge propagator (?)
   .dbg_irq_valid_i             ( '0                                     ), // To edge propagator (?)
+  .mbox_irq_i                  ( '0                                     ),
   .pf_evt_ack_i                ( '1                                     ), // To edge propagator (?)
   .pf_evt_valid_o              (                                        ), // To edge propagator (?)
   .async_cluster_events_wptr_i ( '0                                     ), // To edge propagator (?)


### PR DESCRIPTION
This PR:
* Bumps PULP cluster commit to the one updated with the new reset scheme;
* Extends the integer_cluster instance with the `pwr_on_rst_ni` and the `mbox_irq_i` signals.