### PR TITLE
Update floating-point cluster reset interface 

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -450,7 +450,7 @@ packages:
     - common_cells
     - register_interface
   spatz:
-    revision: fe6af882359be12b3884b9c9a5755a022bb031ff
+    revision: dbc4c442bd54a538bcafd0d62fec2b608a359dc3
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:spatz/spatz.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ dependencies:
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
-  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: fe6af882359be12b3884b9c9a5755a022bb031ff } # branch: main
+  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: dbc4c442bd54a538bcafd0d62fec2b608a359dc3 } # branch: main
   bus_err_unit:       { git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git,          rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 } # branch: main
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.29.0                               }
 

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -997,7 +997,6 @@ spatz_cluster_wrapper #(
     .AxiInIdWidth             ( AxiSlvIdWidth   ),
     .AxiOutIdWidth            ( Cfg.AxiMstIdWidth ),
     .LogDepth                 ( LogDepth ),
-    .SyncStages               (  ), //by default is 3
 
     // AXI type IN
     .axi_in_resp_t            ( carfield_axi_slv_rsp_t     ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -997,6 +997,7 @@ spatz_cluster_wrapper #(
     .AxiInIdWidth             ( AxiSlvIdWidth   ),
     .AxiOutIdWidth            ( Cfg.AxiMstIdWidth ),
     .LogDepth                 ( LogDepth ),
+    .SyncStages               (  ), //by default is 3
 
     // AXI type IN
     .axi_in_resp_t            ( carfield_axi_slv_rsp_t     ),
@@ -1032,8 +1033,7 @@ spatz_cluster_wrapper #(
     )i_fp_cluster_wrapper(
     .clk_i           ( alt_clk_i            ),
     .rst_ni          ( spatz_rst_n          ),
-  // TODO: add pwr_on_rst (!)
-  // TODO: add synth wrapper and isolate stuff like safety island
+    .pwr_on_rst_ni   ( spatz_pwr_on_rst_n   ),
     .testmode_i      ( 1'b0                 ), // TODO: connect
     .scan_enable_i   ( 1'b0                 ),
     .scan_data_i     ( 1'b0                 ),


### PR DESCRIPTION
Here you can fid the reset strategy updates on the spatz cluster.
It automatically generates the wrapper with the interface you can see in carfield.sv
The power_on reset is probed to the isolate and the CDCs.
The reset_ni goes internally to the cluster and it is synchronized with its interrupts.