### PR TITLE
Add synthesis flow steps to carfield CI flow

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -18,3 +18,4 @@ jobs:
           domain: iis-git.ee.ethz.ch
           repo: github-mirror/carfield
           token: ${{ secrets.GITLAB_TOKEN }}
+          poll-count: 2160

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,13 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= a5351b2b161e896592b596492bff1abfac367aca
+CAR_NONFREE_COMMIT ?= 185ca77030bd9053b4a26c9cc0aa4d8d439d1cea
 
 car-nonfree-init:
 	git clone $(CAR_NONFREE_REMOTE) nonfree
 	cd nonfree && git checkout $(CAR_NONFREE_COMMIT)
 
 -include nonfree/nonfree.mk
--include scripts/spy.mk
 
 ############
 # Build SW #


### PR DESCRIPTION
* Add synthesis flow up to compilation (excluded). Top level is `carfield` in `carfield.sv`.

It includes:

1. Analyze
2. Elaborate
3. Link
4. Timing loop check

* The job fails when there is an `Error` in one of the reports, or when a `timing loop` is detected.

* The job is ~30min, which is affordable

