### PR TITLE
Update shared L2 reset strategy

### DIFF
--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -787,7 +787,7 @@ l2_wrap #(
   .NumRules     ( L2NumRules             ),
   .L2MemSize    ( L2MemSize              )
 ) i_reconfigurable_l2 (
-  .clk_i               ( host_clk_i                           ), // TODO: which clock domain? is
+  .clk_i               ( alt_clk_i                            ), // TODO: which clock domain? is
                                                                  // hostd clock domain feasible?
   .rst_ni              ( l2_rst_n                             ),
   .pwr_on_rst_ni       ( l2_pwr_on_rst_n                      ),
@@ -1044,7 +1044,7 @@ spatz_cluster_wrapper #(
     .AsyncAxiOutArWidth       ( CarfieldAxiMstArWidth ),
     .AsyncAxiOutRWidth        ( CarfieldAxiMstRWidth  )
     )i_fp_cluster_wrapper(
-    .clk_i           ( alt_clk_i            ),
+    .clk_i           ( host_clk_i           ),
     .rst_ni          ( spatz_rst_n          ),
     .pwr_on_rst_ni   ( spatz_pwr_on_rst_n   ),
     .testmode_i      ( 1'b0                 ), // TODO: connect

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -786,7 +786,7 @@ l2_wrap #(
   .LogDepth     ( LogDepth               ),
   .NumRules     ( L2NumRules             ),
   .L2MemSize    ( L2MemSize              )
-) i_reconfigrurable_l2 (
+) i_reconfigurable_l2 (
   .clk_i               ( host_clk_i                           ), // TODO: which clock domain? is
                                                                  // hostd clock domain feasible?
   .rst_ni              ( l2_rst_n                             ),

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -339,13 +339,16 @@ carfield_hw2reg_t car_regs_hw2reg;
 // We have three clock domains
 // host (host_clk_i), periph (periph_clk_i) and accelerators (alt_clk_i)
 //
-// and six reset domains
-// host           (contained in host clock domain)
-// periph         (contained in periph clock domain, sw reset 0)
-// safety         (contained in accelerator clock domain, sw reset 1)
-// security       (contained in accelerator clock domain, sw reset 2)
-// pulp_cluster   (contained in accelerator clock domain, sw reset 3)
-// spatz_cluster  (contained in accelerator clock domain, sw reset 4)
+// and seven reset domains
+// host             (contained in host clock domain)
+// periph           (contained in periph clock domain,      sw reset 0)
+// safety           (contained in accelerator clock domain, sw reset 1)
+// security         (contained in accelerator clock domain, sw reset 2)
+// pulp_cluster     (contained in accelerator clock domain, sw reset 3)
+// spatz_cluster    (contained in accelerator clock domain, sw reset 4)
+// shared l2 memory (contained in host clock domain,        sw reset 5)
+
+localparam int unsigned NumRstDomains = 6;
 
 logic    periph_rst_n;
 logic    safety_rst_n;
@@ -377,36 +380,39 @@ rstgen i_host_rstgen (
 
 // Note that each accelerator has two resets: One for the combined
 // software/power-on reset and a power-on reset only
-logic [4:0] pwr_on_rsts_n;
-logic [4:0] rsts_n;
+logic [NumRstDomains-1:0] pwr_on_rsts_n;
+logic [NumRstDomains-1:0] rsts_n;
 
 carfield_rstgen #(
-  .NumRstDomains (5)
+  .NumRstDomains (NumRstDomains)
 ) i_carfield_rstgen (
-  .clks_i({periph_clk_i, alt_clk_i, alt_clk_i, alt_clk_i, alt_clk_i}),
+  .clks_i({periph_clk_i, alt_clk_i, alt_clk_i, alt_clk_i, host_clk_i, alt_clk_i}),
   .pwr_on_rst_ni,
   .sw_rsts_ni(~{car_regs_reg2hw.periph_rst.q,
                 car_regs_reg2hw.safety_island_rst.q,
                 car_regs_reg2hw.security_island_rst.q,
                 car_regs_reg2hw.pulp_cluster_rst.q,
-                car_regs_reg2hw.spatz_cluster_rst.q}),
+                car_regs_reg2hw.spatz_cluster_rst.q,
+                car_regs_reg2hw.l2_rst.q}),
   .test_mode_i,
   .rsts_no(rsts_n),
   .pwr_on_rsts_no(pwr_on_rsts_n),
   .inits_no() // TODO: connect ?
 );
 
-assign periph_rst_n = rsts_n[0];
-assign safety_rst_n = rsts_n[1];
-assign security_rst_n = rsts_n[2];
-assign pulp_rst_n = rsts_n[3];
-assign spatz_rst_n = rsts_n[4];
+assign periph_rst_n   = rsts_n[PeriphRstDomainIdx];
+assign safety_rst_n   = rsts_n[SafedRstDomainIdx];
+assign security_rst_n = rsts_n[SecdRstDomainIdx];
+assign pulp_rst_n     = rsts_n[IntClusterRstDomainIdx];
+assign spatz_rst_n    = rsts_n[FPClusterRstDomainIdx];
+assign l2_rst_n       = rsts_n[L2RstDomainIdx];
 
-assign periph_pwr_on_rst_n = pwr_on_rsts_n[0];
-assign safety_pwr_on_rst_n = pwr_on_rsts_n[1];
-assign security_pwr_on_rst_n = pwr_on_rsts_n[2];
-assign pulp_pwr_on_rst_n = pwr_on_rsts_n[3];
-assign spatz_pwr_on_rst_n = pwr_on_rsts_n[4];
+assign periph_pwr_on_rst_n   = pwr_on_rsts_n[PeriphRstDomainIdx];
+assign safety_pwr_on_rst_n   = pwr_on_rsts_n[SafedRstDomainIdx];
+assign security_pwr_on_rst_n = pwr_on_rsts_n[SecdRstDomainIdx];
+assign pulp_pwr_on_rst_n     = pwr_on_rsts_n[IntClusterRstDomainIdx];
+assign spatz_pwr_on_rst_n    = pwr_on_rsts_n[FPClusterRstDomainIdx];
+assign l2_pwr_on_rst_n       = pwr_on_rsts_n[L2RstDomainIdx];
 
 //
 // Carfield Control and Status registers
@@ -781,8 +787,10 @@ l2_wrap #(
   .NumRules     ( L2NumRules             ),
   .L2MemSize    ( L2MemSize              )
 ) i_reconfigrurable_l2 (
-  .clk_i               ( host_clk_i                           ),
-  .rst_ni              ( host_pwr_on_rst_n                    ),
+  .clk_i               ( host_clk_i                           ), // TODO: which clock domain? is
+                                                                 // hostd clock domain feasible?
+  .rst_ni              ( l2_rst_n                             ),
+  .pwr_on_rst_ni       ( l2_pwr_on_rst_n                      ),
   .slvport_ar_data_i   ( axi_slv_ext_ar_data [NumL2Ports-1:0] ),
   .slvport_ar_wptr_i   ( axi_slv_ext_ar_wptr [NumL2Ports-1:0] ),
   .slvport_ar_rptr_o   ( axi_slv_ext_ar_rptr [NumL2Ports-1:0] ),

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -11,6 +11,15 @@ package carfield_pkg;
 
 import cheshire_pkg::*;
 
+typedef enum int {
+  PeriphRstDomainIdx     = 'd0,
+  SafedRstDomainIdx      = 'd1,
+  SecdRstDomainIdx       = 'd2,
+  IntClusterRstDomainIdx = 'd3,
+  FPClusterRstDomainIdx  = 'd4,
+  L2RstDomainIdx         = 'd5
+} carfield_rst_domains_e;
+
 typedef enum byte_bt {
   L2Port1SlvIdx      = 'd0,
   L2Port2SlvIdx      = 'd1,

--- a/hw/l2_wrap.sv
+++ b/hw/l2_wrap.sv
@@ -47,6 +47,7 @@ module l2_wrap
 )(
   input  logic                            clk_i            ,
   input  logic                            rst_ni           ,
+  input  logic                            pwr_on_rst_ni    ,
   input  logic [NumPort-1:0][ArWidth-1:0] slvport_ar_data_i,
   input  logic [NumPort-1:0][ LogDepth:0] slvport_ar_wptr_i,
   output logic [NumPort-1:0][ LogDepth:0] slvport_ar_rptr_o,
@@ -101,7 +102,7 @@ for (genvar i = 0; i < NumPort; i++) begin: gen_cdc_fifos
     .async_data_slave_r_rptr_i  ( slvport_r_rptr_i  [i] ),
     // synchronous master port
     .dst_clk_i  ( clk_i             ),
-    .dst_rst_ni ( rst_ni            ),
+    .dst_rst_ni ( pwr_on_rst_ni     ),
     .dst_req_o  ( axi_async_req [i] ),
     .dst_resp_i ( axi_async_rsp [i] )
   );

--- a/hw/regs/carfield_reg_pkg.sv
+++ b/hw/regs/carfield_reg_pkg.sv
@@ -51,6 +51,10 @@ package carfield_reg_pkg;
 
   typedef struct packed {
     logic        q;
+  } carfield_reg2hw_l2_rst_reg_t;
+
+  typedef struct packed {
+    logic        q;
   } carfield_reg2hw_host_isolate_reg_t;
 
   typedef struct packed {
@@ -176,15 +180,16 @@ package carfield_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    carfield_reg2hw_boot_mode_reg_t boot_mode; // [371:369]
-    carfield_reg2hw_generic_scratch0_reg_t generic_scratch0; // [368:337]
-    carfield_reg2hw_generic_scratch1_reg_t generic_scratch1; // [336:305]
-    carfield_reg2hw_host_rst_reg_t host_rst; // [304:304]
-    carfield_reg2hw_periph_rst_reg_t periph_rst; // [303:303]
-    carfield_reg2hw_safety_island_rst_reg_t safety_island_rst; // [302:302]
-    carfield_reg2hw_security_island_rst_reg_t security_island_rst; // [301:301]
-    carfield_reg2hw_pulp_cluster_rst_reg_t pulp_cluster_rst; // [300:300]
-    carfield_reg2hw_spatz_cluster_rst_reg_t spatz_cluster_rst; // [299:299]
+    carfield_reg2hw_boot_mode_reg_t boot_mode; // [372:370]
+    carfield_reg2hw_generic_scratch0_reg_t generic_scratch0; // [369:338]
+    carfield_reg2hw_generic_scratch1_reg_t generic_scratch1; // [337:306]
+    carfield_reg2hw_host_rst_reg_t host_rst; // [305:305]
+    carfield_reg2hw_periph_rst_reg_t periph_rst; // [304:304]
+    carfield_reg2hw_safety_island_rst_reg_t safety_island_rst; // [303:303]
+    carfield_reg2hw_security_island_rst_reg_t security_island_rst; // [302:302]
+    carfield_reg2hw_pulp_cluster_rst_reg_t pulp_cluster_rst; // [301:301]
+    carfield_reg2hw_spatz_cluster_rst_reg_t spatz_cluster_rst; // [300:300]
+    carfield_reg2hw_l2_rst_reg_t l2_rst; // [299:299]
     carfield_reg2hw_host_isolate_reg_t host_isolate; // [298:298]
     carfield_reg2hw_periph_isolate_reg_t periph_isolate; // [297:297]
     carfield_reg2hw_safety_island_isolate_reg_t safety_island_isolate; // [296:296]
@@ -236,32 +241,33 @@ package carfield_reg_pkg;
   parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_RST_OFFSET = 8'h 30;
   parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_RST_OFFSET = 8'h 34;
   parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_RST_OFFSET = 8'h 38;
-  parameter logic [BlockAw-1:0] CARFIELD_HOST_ISOLATE_OFFSET = 8'h 3c;
-  parameter logic [BlockAw-1:0] CARFIELD_PERIPH_ISOLATE_OFFSET = 8'h 40;
-  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_ISOLATE_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_ISOLATE_OFFSET = 8'h 48;
-  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_ISOLATE_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_ISOLATE_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] CARFIELD_HOST_ISOLATE_STATUS_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] CARFIELD_PERIPH_ISOLATE_STATUS_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_ISOLATE_STATUS_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] CARFIELD_HOST_FETCH_ENABLE_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_FETCH_ENABLE_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_FETCH_ENABLE_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_FETCH_ENABLE_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] CARFIELD_HOST_BOOT_ADDR_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_BOOT_ADDR_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_BOOT_ADDR_OFFSET = 8'h 88;
-  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_BOOT_ADDR_OFFSET = 8'h 8c;
-  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_BOOT_ADDR_OFFSET = 8'h 90;
-  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG0_OFFSET = 8'h 94;
-  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG1_OFFSET = 8'h 98;
-  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG2_OFFSET = 8'h 9c;
-  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG3_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] CARFIELD_L2_RST_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] CARFIELD_HOST_ISOLATE_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] CARFIELD_PERIPH_ISOLATE_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_ISOLATE_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_ISOLATE_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_ISOLATE_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_ISOLATE_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] CARFIELD_HOST_ISOLATE_STATUS_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] CARFIELD_PERIPH_ISOLATE_STATUS_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_ISOLATE_STATUS_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] CARFIELD_HOST_FETCH_ENABLE_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_FETCH_ENABLE_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_FETCH_ENABLE_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_FETCH_ENABLE_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] CARFIELD_HOST_BOOT_ADDR_OFFSET = 8'h 84;
+  parameter logic [BlockAw-1:0] CARFIELD_SAFETY_ISLAND_BOOT_ADDR_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] CARFIELD_SECURITY_ISLAND_BOOT_ADDR_OFFSET = 8'h 8c;
+  parameter logic [BlockAw-1:0] CARFIELD_PULP_CLUSTER_BOOT_ADDR_OFFSET = 8'h 90;
+  parameter logic [BlockAw-1:0] CARFIELD_SPATZ_CLUSTER_BOOT_ADDR_OFFSET = 8'h 94;
+  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG0_OFFSET = 8'h 98;
+  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG1_OFFSET = 8'h 9c;
+  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG2_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] CARFIELD_L2_SRAM_CONFIG3_OFFSET = 8'h a4;
 
   // Register index
   typedef enum int {
@@ -280,6 +286,7 @@ package carfield_reg_pkg;
     CARFIELD_SECURITY_ISLAND_RST,
     CARFIELD_PULP_CLUSTER_RST,
     CARFIELD_SPATZ_CLUSTER_RST,
+    CARFIELD_L2_RST,
     CARFIELD_HOST_ISOLATE,
     CARFIELD_PERIPH_ISOLATE,
     CARFIELD_SAFETY_ISLAND_ISOLATE,
@@ -309,7 +316,7 @@ package carfield_reg_pkg;
   } carfield_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CARFIELD_PERMIT [41] = '{
+  parameter logic [3:0] CARFIELD_PERMIT [42] = '{
     4'b 1111, // index[ 0] CARFIELD_VERSION0
     4'b 1111, // index[ 1] CARFIELD_VERSION1
     4'b 1111, // index[ 2] CARFIELD_VERSION2
@@ -325,32 +332,33 @@ package carfield_reg_pkg;
     4'b 0001, // index[12] CARFIELD_SECURITY_ISLAND_RST
     4'b 0001, // index[13] CARFIELD_PULP_CLUSTER_RST
     4'b 0001, // index[14] CARFIELD_SPATZ_CLUSTER_RST
-    4'b 0001, // index[15] CARFIELD_HOST_ISOLATE
-    4'b 0001, // index[16] CARFIELD_PERIPH_ISOLATE
-    4'b 0001, // index[17] CARFIELD_SAFETY_ISLAND_ISOLATE
-    4'b 0001, // index[18] CARFIELD_SECURITY_ISLAND_ISOLATE
-    4'b 0001, // index[19] CARFIELD_PULP_CLUSTER_ISOLATE
-    4'b 0001, // index[20] CARFIELD_SPATZ_CLUSTER_ISOLATE
-    4'b 0001, // index[21] CARFIELD_HOST_ISOLATE_STATUS
-    4'b 0001, // index[22] CARFIELD_PERIPH_ISOLATE_STATUS
-    4'b 0001, // index[23] CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS
-    4'b 0001, // index[24] CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS
-    4'b 0001, // index[25] CARFIELD_PULP_CLUSTER_ISOLATE_STATUS
-    4'b 0001, // index[26] CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS
-    4'b 0001, // index[27] CARFIELD_HOST_FETCH_ENABLE
-    4'b 0001, // index[28] CARFIELD_SAFETY_ISLAND_FETCH_ENABLE
-    4'b 0001, // index[29] CARFIELD_SECURITY_ISLAND_FETCH_ENABLE
-    4'b 0001, // index[30] CARFIELD_PULP_CLUSTER_FETCH_ENABLE
-    4'b 0001, // index[31] CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE
-    4'b 1111, // index[32] CARFIELD_HOST_BOOT_ADDR
-    4'b 1111, // index[33] CARFIELD_SAFETY_ISLAND_BOOT_ADDR
-    4'b 1111, // index[34] CARFIELD_SECURITY_ISLAND_BOOT_ADDR
-    4'b 1111, // index[35] CARFIELD_PULP_CLUSTER_BOOT_ADDR
-    4'b 1111, // index[36] CARFIELD_SPATZ_CLUSTER_BOOT_ADDR
-    4'b 1111, // index[37] CARFIELD_L2_SRAM_CONFIG0
-    4'b 1111, // index[38] CARFIELD_L2_SRAM_CONFIG1
-    4'b 1111, // index[39] CARFIELD_L2_SRAM_CONFIG2
-    4'b 1111  // index[40] CARFIELD_L2_SRAM_CONFIG3
+    4'b 0001, // index[15] CARFIELD_L2_RST
+    4'b 0001, // index[16] CARFIELD_HOST_ISOLATE
+    4'b 0001, // index[17] CARFIELD_PERIPH_ISOLATE
+    4'b 0001, // index[18] CARFIELD_SAFETY_ISLAND_ISOLATE
+    4'b 0001, // index[19] CARFIELD_SECURITY_ISLAND_ISOLATE
+    4'b 0001, // index[20] CARFIELD_PULP_CLUSTER_ISOLATE
+    4'b 0001, // index[21] CARFIELD_SPATZ_CLUSTER_ISOLATE
+    4'b 0001, // index[22] CARFIELD_HOST_ISOLATE_STATUS
+    4'b 0001, // index[23] CARFIELD_PERIPH_ISOLATE_STATUS
+    4'b 0001, // index[24] CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS
+    4'b 0001, // index[25] CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS
+    4'b 0001, // index[26] CARFIELD_PULP_CLUSTER_ISOLATE_STATUS
+    4'b 0001, // index[27] CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS
+    4'b 0001, // index[28] CARFIELD_HOST_FETCH_ENABLE
+    4'b 0001, // index[29] CARFIELD_SAFETY_ISLAND_FETCH_ENABLE
+    4'b 0001, // index[30] CARFIELD_SECURITY_ISLAND_FETCH_ENABLE
+    4'b 0001, // index[31] CARFIELD_PULP_CLUSTER_FETCH_ENABLE
+    4'b 0001, // index[32] CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE
+    4'b 1111, // index[33] CARFIELD_HOST_BOOT_ADDR
+    4'b 1111, // index[34] CARFIELD_SAFETY_ISLAND_BOOT_ADDR
+    4'b 1111, // index[35] CARFIELD_SECURITY_ISLAND_BOOT_ADDR
+    4'b 1111, // index[36] CARFIELD_PULP_CLUSTER_BOOT_ADDR
+    4'b 1111, // index[37] CARFIELD_SPATZ_CLUSTER_BOOT_ADDR
+    4'b 1111, // index[38] CARFIELD_L2_SRAM_CONFIG0
+    4'b 1111, // index[39] CARFIELD_L2_SRAM_CONFIG1
+    4'b 1111, // index[40] CARFIELD_L2_SRAM_CONFIG2
+    4'b 1111  // index[41] CARFIELD_L2_SRAM_CONFIG3
   };
 
 endpackage

--- a/hw/regs/carfield_reg_top.sv
+++ b/hw/regs/carfield_reg_top.sv
@@ -99,6 +99,9 @@ module carfield_reg_top #(
   logic spatz_cluster_rst_qs;
   logic spatz_cluster_rst_wd;
   logic spatz_cluster_rst_we;
+  logic l2_rst_qs;
+  logic l2_rst_wd;
+  logic l2_rst_we;
   logic host_isolate_qs;
   logic periph_isolate_qs;
   logic periph_isolate_wd;
@@ -468,6 +471,33 @@ module carfield_reg_top #(
 
     // to register interface (read)
     .qs     (spatz_cluster_rst_qs)
+  );
+
+
+  // R[l2_rst]: V(False)
+
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("RW"),
+    .RESVAL  (1'h0)
+  ) u_l2_rst (
+    .clk_i   (clk_i    ),
+    .rst_ni  (rst_ni  ),
+
+    // from register interface
+    .we     (l2_rst_we),
+    .wd     (l2_rst_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0  ),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.l2_rst.q ),
+
+    // to register interface (read)
+    .qs     (l2_rst_qs)
   );
 
 
@@ -1172,7 +1202,7 @@ module carfield_reg_top #(
 
 
 
-  logic [40:0] addr_hit;
+  logic [41:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CARFIELD_VERSION0_OFFSET);
@@ -1190,32 +1220,33 @@ module carfield_reg_top #(
     addr_hit[12] = (reg_addr == CARFIELD_SECURITY_ISLAND_RST_OFFSET);
     addr_hit[13] = (reg_addr == CARFIELD_PULP_CLUSTER_RST_OFFSET);
     addr_hit[14] = (reg_addr == CARFIELD_SPATZ_CLUSTER_RST_OFFSET);
-    addr_hit[15] = (reg_addr == CARFIELD_HOST_ISOLATE_OFFSET);
-    addr_hit[16] = (reg_addr == CARFIELD_PERIPH_ISOLATE_OFFSET);
-    addr_hit[17] = (reg_addr == CARFIELD_SAFETY_ISLAND_ISOLATE_OFFSET);
-    addr_hit[18] = (reg_addr == CARFIELD_SECURITY_ISLAND_ISOLATE_OFFSET);
-    addr_hit[19] = (reg_addr == CARFIELD_PULP_CLUSTER_ISOLATE_OFFSET);
-    addr_hit[20] = (reg_addr == CARFIELD_SPATZ_CLUSTER_ISOLATE_OFFSET);
-    addr_hit[21] = (reg_addr == CARFIELD_HOST_ISOLATE_STATUS_OFFSET);
-    addr_hit[22] = (reg_addr == CARFIELD_PERIPH_ISOLATE_STATUS_OFFSET);
-    addr_hit[23] = (reg_addr == CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS_OFFSET);
-    addr_hit[24] = (reg_addr == CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS_OFFSET);
-    addr_hit[25] = (reg_addr == CARFIELD_PULP_CLUSTER_ISOLATE_STATUS_OFFSET);
-    addr_hit[26] = (reg_addr == CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS_OFFSET);
-    addr_hit[27] = (reg_addr == CARFIELD_HOST_FETCH_ENABLE_OFFSET);
-    addr_hit[28] = (reg_addr == CARFIELD_SAFETY_ISLAND_FETCH_ENABLE_OFFSET);
-    addr_hit[29] = (reg_addr == CARFIELD_SECURITY_ISLAND_FETCH_ENABLE_OFFSET);
-    addr_hit[30] = (reg_addr == CARFIELD_PULP_CLUSTER_FETCH_ENABLE_OFFSET);
-    addr_hit[31] = (reg_addr == CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE_OFFSET);
-    addr_hit[32] = (reg_addr == CARFIELD_HOST_BOOT_ADDR_OFFSET);
-    addr_hit[33] = (reg_addr == CARFIELD_SAFETY_ISLAND_BOOT_ADDR_OFFSET);
-    addr_hit[34] = (reg_addr == CARFIELD_SECURITY_ISLAND_BOOT_ADDR_OFFSET);
-    addr_hit[35] = (reg_addr == CARFIELD_PULP_CLUSTER_BOOT_ADDR_OFFSET);
-    addr_hit[36] = (reg_addr == CARFIELD_SPATZ_CLUSTER_BOOT_ADDR_OFFSET);
-    addr_hit[37] = (reg_addr == CARFIELD_L2_SRAM_CONFIG0_OFFSET);
-    addr_hit[38] = (reg_addr == CARFIELD_L2_SRAM_CONFIG1_OFFSET);
-    addr_hit[39] = (reg_addr == CARFIELD_L2_SRAM_CONFIG2_OFFSET);
-    addr_hit[40] = (reg_addr == CARFIELD_L2_SRAM_CONFIG3_OFFSET);
+    addr_hit[15] = (reg_addr == CARFIELD_L2_RST_OFFSET);
+    addr_hit[16] = (reg_addr == CARFIELD_HOST_ISOLATE_OFFSET);
+    addr_hit[17] = (reg_addr == CARFIELD_PERIPH_ISOLATE_OFFSET);
+    addr_hit[18] = (reg_addr == CARFIELD_SAFETY_ISLAND_ISOLATE_OFFSET);
+    addr_hit[19] = (reg_addr == CARFIELD_SECURITY_ISLAND_ISOLATE_OFFSET);
+    addr_hit[20] = (reg_addr == CARFIELD_PULP_CLUSTER_ISOLATE_OFFSET);
+    addr_hit[21] = (reg_addr == CARFIELD_SPATZ_CLUSTER_ISOLATE_OFFSET);
+    addr_hit[22] = (reg_addr == CARFIELD_HOST_ISOLATE_STATUS_OFFSET);
+    addr_hit[23] = (reg_addr == CARFIELD_PERIPH_ISOLATE_STATUS_OFFSET);
+    addr_hit[24] = (reg_addr == CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS_OFFSET);
+    addr_hit[25] = (reg_addr == CARFIELD_SECURITY_ISLAND_ISOLATE_STATUS_OFFSET);
+    addr_hit[26] = (reg_addr == CARFIELD_PULP_CLUSTER_ISOLATE_STATUS_OFFSET);
+    addr_hit[27] = (reg_addr == CARFIELD_SPATZ_CLUSTER_ISOLATE_STATUS_OFFSET);
+    addr_hit[28] = (reg_addr == CARFIELD_HOST_FETCH_ENABLE_OFFSET);
+    addr_hit[29] = (reg_addr == CARFIELD_SAFETY_ISLAND_FETCH_ENABLE_OFFSET);
+    addr_hit[30] = (reg_addr == CARFIELD_SECURITY_ISLAND_FETCH_ENABLE_OFFSET);
+    addr_hit[31] = (reg_addr == CARFIELD_PULP_CLUSTER_FETCH_ENABLE_OFFSET);
+    addr_hit[32] = (reg_addr == CARFIELD_SPATZ_CLUSTER_FETCH_ENABLE_OFFSET);
+    addr_hit[33] = (reg_addr == CARFIELD_HOST_BOOT_ADDR_OFFSET);
+    addr_hit[34] = (reg_addr == CARFIELD_SAFETY_ISLAND_BOOT_ADDR_OFFSET);
+    addr_hit[35] = (reg_addr == CARFIELD_SECURITY_ISLAND_BOOT_ADDR_OFFSET);
+    addr_hit[36] = (reg_addr == CARFIELD_PULP_CLUSTER_BOOT_ADDR_OFFSET);
+    addr_hit[37] = (reg_addr == CARFIELD_SPATZ_CLUSTER_BOOT_ADDR_OFFSET);
+    addr_hit[38] = (reg_addr == CARFIELD_L2_SRAM_CONFIG0_OFFSET);
+    addr_hit[39] = (reg_addr == CARFIELD_L2_SRAM_CONFIG1_OFFSET);
+    addr_hit[40] = (reg_addr == CARFIELD_L2_SRAM_CONFIG2_OFFSET);
+    addr_hit[41] = (reg_addr == CARFIELD_L2_SRAM_CONFIG3_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1263,7 +1294,8 @@ module carfield_reg_top #(
                (addr_hit[37] & (|(CARFIELD_PERMIT[37] & ~reg_be))) |
                (addr_hit[38] & (|(CARFIELD_PERMIT[38] & ~reg_be))) |
                (addr_hit[39] & (|(CARFIELD_PERMIT[39] & ~reg_be))) |
-               (addr_hit[40] & (|(CARFIELD_PERMIT[40] & ~reg_be)))));
+               (addr_hit[40] & (|(CARFIELD_PERMIT[40] & ~reg_be))) |
+               (addr_hit[41] & (|(CARFIELD_PERMIT[41] & ~reg_be)))));
   end
 
   assign jedec_idcode_we = addr_hit[6] & reg_we & !reg_error;
@@ -1290,73 +1322,76 @@ module carfield_reg_top #(
   assign spatz_cluster_rst_we = addr_hit[14] & reg_we & !reg_error;
   assign spatz_cluster_rst_wd = reg_wdata[0];
 
-  assign periph_isolate_we = addr_hit[16] & reg_we & !reg_error;
+  assign l2_rst_we = addr_hit[15] & reg_we & !reg_error;
+  assign l2_rst_wd = reg_wdata[0];
+
+  assign periph_isolate_we = addr_hit[17] & reg_we & !reg_error;
   assign periph_isolate_wd = reg_wdata[0];
 
-  assign safety_island_isolate_we = addr_hit[17] & reg_we & !reg_error;
+  assign safety_island_isolate_we = addr_hit[18] & reg_we & !reg_error;
   assign safety_island_isolate_wd = reg_wdata[0];
 
-  assign security_island_isolate_we = addr_hit[18] & reg_we & !reg_error;
+  assign security_island_isolate_we = addr_hit[19] & reg_we & !reg_error;
   assign security_island_isolate_wd = reg_wdata[0];
 
-  assign pulp_cluster_isolate_we = addr_hit[19] & reg_we & !reg_error;
+  assign pulp_cluster_isolate_we = addr_hit[20] & reg_we & !reg_error;
   assign pulp_cluster_isolate_wd = reg_wdata[0];
 
-  assign spatz_cluster_isolate_we = addr_hit[20] & reg_we & !reg_error;
+  assign spatz_cluster_isolate_we = addr_hit[21] & reg_we & !reg_error;
   assign spatz_cluster_isolate_wd = reg_wdata[0];
 
-  assign periph_isolate_status_we = addr_hit[22] & reg_we & !reg_error;
+  assign periph_isolate_status_we = addr_hit[23] & reg_we & !reg_error;
   assign periph_isolate_status_wd = reg_wdata[0];
 
-  assign safety_island_isolate_status_we = addr_hit[23] & reg_we & !reg_error;
+  assign safety_island_isolate_status_we = addr_hit[24] & reg_we & !reg_error;
   assign safety_island_isolate_status_wd = reg_wdata[0];
 
-  assign security_island_isolate_status_we = addr_hit[24] & reg_we & !reg_error;
+  assign security_island_isolate_status_we = addr_hit[25] & reg_we & !reg_error;
   assign security_island_isolate_status_wd = reg_wdata[0];
 
-  assign pulp_cluster_isolate_status_we = addr_hit[25] & reg_we & !reg_error;
+  assign pulp_cluster_isolate_status_we = addr_hit[26] & reg_we & !reg_error;
   assign pulp_cluster_isolate_status_wd = reg_wdata[0];
 
-  assign spatz_cluster_isolate_status_we = addr_hit[26] & reg_we & !reg_error;
+  assign spatz_cluster_isolate_status_we = addr_hit[27] & reg_we & !reg_error;
   assign spatz_cluster_isolate_status_wd = reg_wdata[0];
 
-  assign safety_island_fetch_enable_we = addr_hit[28] & reg_we & !reg_error;
+  assign safety_island_fetch_enable_we = addr_hit[29] & reg_we & !reg_error;
   assign safety_island_fetch_enable_wd = reg_wdata[0];
 
-  assign security_island_fetch_enable_we = addr_hit[29] & reg_we & !reg_error;
+  assign security_island_fetch_enable_we = addr_hit[30] & reg_we & !reg_error;
   assign security_island_fetch_enable_wd = reg_wdata[0];
 
-  assign pulp_cluster_fetch_enable_we = addr_hit[30] & reg_we & !reg_error;
+  assign pulp_cluster_fetch_enable_we = addr_hit[31] & reg_we & !reg_error;
   assign pulp_cluster_fetch_enable_wd = reg_wdata[0];
 
-  assign spatz_cluster_fetch_enable_we = addr_hit[31] & reg_we & !reg_error;
+  assign spatz_cluster_fetch_enable_we = addr_hit[32] & reg_we & !reg_error;
   assign spatz_cluster_fetch_enable_wd = reg_wdata[0];
 
-  assign host_boot_addr_we = addr_hit[32] & reg_we & !reg_error;
+  assign host_boot_addr_we = addr_hit[33] & reg_we & !reg_error;
   assign host_boot_addr_wd = reg_wdata[31:0];
 
-  assign safety_island_boot_addr_we = addr_hit[33] & reg_we & !reg_error;
+  assign safety_island_boot_addr_we = addr_hit[34] & reg_we & !reg_error;
   assign safety_island_boot_addr_wd = reg_wdata[31:0];
 
-  assign security_island_boot_addr_we = addr_hit[34] & reg_we & !reg_error;
+  assign security_island_boot_addr_we = addr_hit[35] & reg_we & !reg_error;
   assign security_island_boot_addr_wd = reg_wdata[31:0];
 
-  assign pulp_cluster_boot_addr_we = addr_hit[35] & reg_we & !reg_error;
+  assign pulp_cluster_boot_addr_we = addr_hit[36] & reg_we & !reg_error;
   assign pulp_cluster_boot_addr_wd = reg_wdata[31:0];
 
-  assign spatz_cluster_boot_addr_we = addr_hit[36] & reg_we & !reg_error;
+  assign spatz_cluster_boot_addr_we = addr_hit[37] & reg_we & !reg_error;
   assign spatz_cluster_boot_addr_wd = reg_wdata[31:0];
 
-  assign l2_sram_config0_we = addr_hit[37] & reg_we & !reg_error;
+  assign l2_sram_config0_we = addr_hit[38] & reg_we & !reg_error;
   assign l2_sram_config0_wd = reg_wdata[31:0];
 
-  assign l2_sram_config1_we = addr_hit[38] & reg_we & !reg_error;
+  assign l2_sram_config1_we = addr_hit[39] & reg_we & !reg_error;
   assign l2_sram_config1_wd = reg_wdata[31:0];
 
-  assign l2_sram_config2_we = addr_hit[39] & reg_we & !reg_error;
+  assign l2_sram_config2_we = addr_hit[40] & reg_we & !reg_error;
   assign l2_sram_config2_wd = reg_wdata[31:0];
 
-  assign l2_sram_config3_we = addr_hit[40] & reg_we & !reg_error;
+  assign l2_sram_config3_we = addr_hit[41] & reg_we & !reg_error;
   assign l2_sram_config3_wd = reg_wdata[31:0];
 
   // Read data return
@@ -1424,106 +1459,110 @@ module carfield_reg_top #(
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[0] = host_isolate_qs;
+        reg_rdata_next[0] = l2_rst_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[0] = periph_isolate_qs;
+        reg_rdata_next[0] = host_isolate_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[0] = safety_island_isolate_qs;
+        reg_rdata_next[0] = periph_isolate_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[0] = security_island_isolate_qs;
+        reg_rdata_next[0] = safety_island_isolate_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[0] = pulp_cluster_isolate_qs;
+        reg_rdata_next[0] = security_island_isolate_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[0] = spatz_cluster_isolate_qs;
+        reg_rdata_next[0] = pulp_cluster_isolate_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[0] = host_isolate_status_qs;
+        reg_rdata_next[0] = spatz_cluster_isolate_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[0] = periph_isolate_status_qs;
+        reg_rdata_next[0] = host_isolate_status_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[0] = safety_island_isolate_status_qs;
+        reg_rdata_next[0] = periph_isolate_status_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[0] = security_island_isolate_status_qs;
+        reg_rdata_next[0] = safety_island_isolate_status_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[0] = pulp_cluster_isolate_status_qs;
+        reg_rdata_next[0] = security_island_isolate_status_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[0] = spatz_cluster_isolate_status_qs;
+        reg_rdata_next[0] = pulp_cluster_isolate_status_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[0] = host_fetch_enable_qs;
+        reg_rdata_next[0] = spatz_cluster_isolate_status_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[0] = safety_island_fetch_enable_qs;
+        reg_rdata_next[0] = host_fetch_enable_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[0] = security_island_fetch_enable_qs;
+        reg_rdata_next[0] = safety_island_fetch_enable_qs;
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[0] = pulp_cluster_fetch_enable_qs;
+        reg_rdata_next[0] = security_island_fetch_enable_qs;
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[0] = spatz_cluster_fetch_enable_qs;
+        reg_rdata_next[0] = pulp_cluster_fetch_enable_qs;
       end
 
       addr_hit[32]: begin
-        reg_rdata_next[31:0] = host_boot_addr_qs;
+        reg_rdata_next[0] = spatz_cluster_fetch_enable_qs;
       end
 
       addr_hit[33]: begin
-        reg_rdata_next[31:0] = safety_island_boot_addr_qs;
+        reg_rdata_next[31:0] = host_boot_addr_qs;
       end
 
       addr_hit[34]: begin
-        reg_rdata_next[31:0] = security_island_boot_addr_qs;
+        reg_rdata_next[31:0] = safety_island_boot_addr_qs;
       end
 
       addr_hit[35]: begin
-        reg_rdata_next[31:0] = pulp_cluster_boot_addr_qs;
+        reg_rdata_next[31:0] = security_island_boot_addr_qs;
       end
 
       addr_hit[36]: begin
-        reg_rdata_next[31:0] = spatz_cluster_boot_addr_qs;
+        reg_rdata_next[31:0] = pulp_cluster_boot_addr_qs;
       end
 
       addr_hit[37]: begin
-        reg_rdata_next[31:0] = l2_sram_config0_qs;
+        reg_rdata_next[31:0] = spatz_cluster_boot_addr_qs;
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[31:0] = l2_sram_config1_qs;
+        reg_rdata_next[31:0] = l2_sram_config0_qs;
       end
 
       addr_hit[39]: begin
-        reg_rdata_next[31:0] = l2_sram_config2_qs;
+        reg_rdata_next[31:0] = l2_sram_config1_qs;
       end
 
       addr_hit[40]: begin
+        reg_rdata_next[31:0] = l2_sram_config2_qs;
+      end
+
+      addr_hit[41]: begin
         reg_rdata_next[31:0] = l2_sram_config3_qs;
       end
 

--- a/hw/regs/carfield_regs.csv
+++ b/hw/regs/carfield_regs.csv
@@ -14,6 +14,7 @@ SAFETY_ISLAND_RST,1,rw,hro,0,"Safety Island reset -active high, inverted in HW-"
 SECURITY_ISLAND_RST,1,rw,hro,0,"Security Island reset -active high, inverted in HW-"
 PULP_CLUSTER_RST,1,rw,hro,0,"PULP Cluster reset -active high, inverted in HW-"
 SPATZ_CLUSTER_RST,1,rw,hro,0,"Spatz Cluster reset -active high, inverted in HW-"
+L2_RST,1,rw,hro,0,"L2 reset -active high, inverted in HW-"
 HOST_ISOLATE,1,ro,hro,0,Host Domain AXI isolate
 PERIPH_ISOLATE,1,rw,hro,0,Periph Domain  AXI isolate
 SAFETY_ISLAND_ISOLATE,1,rw,hro,0,Safety Island AXI isolate

--- a/hw/regs/carfield_regs.hjson
+++ b/hw/regs/carfield_regs.hjson
@@ -162,6 +162,16 @@
       ],
     }
 
+    { name: "L2_RST",
+      desc: "L2 reset -active high, inverted in HW-",
+      swaccess: "rw",
+      hwaccess: "hro",
+      resval: "0",
+      fields: [
+        { bits: "0:0" }
+      ],
+    }
+
     { name: "HOST_ISOLATE",
       desc: "Host Domain AXI isolate",
       swaccess: "ro",


### PR DESCRIPTION
Modify L2_wrap to align with the SoC reset scheme. 

- [x] Add one global power reset signal, which connects to CDC in the wrap
- [x] Add software reset for L2 in carfield clock and reset control registers 