### PR TITLE
Properly connect the hyperbus peripheral to the right clock domain

### DIFF
--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -120,9 +120,6 @@ module carfield
   output logic [SlinkNumChan-1:0]                     slink_rcv_clk_o,
   input  logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_i,
   output logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_o,
-  // HyperBus clocks
-  input  logic                                        hyp_clk_phy_i,
-  input  logic                                        hyp_rst_phy_ni,
   // HyperBus interface
   output logic [HypNumPhys-1:0][HypNumChips-1:0]      hyper_cs_no,
   output logic [HypNumPhys-1:0]                       hyper_ck_o,
@@ -986,8 +983,8 @@ hyperbus_wrap      #(
   .AxiSlaveWWidth   ( LlcWWidth                             ),
   .AxiMaxTrans      ( Cfg.AxiMaxSlvTrans                    )
 ) i_hyperbus_wrap   (
-  .clk_i               ( hyp_clk_phy_i      ),
-  .rst_ni              ( hyp_rst_phy_ni     ),
+  .clk_i               ( periph_clk         ),
+  .rst_ni              ( periph_rst_n       ),
   .test_mode_i         ( test_mode_i        ),
   .axi_slave_ar_data_i ( llc_ar_data        ),
   .axi_slave_ar_wptr_i ( llc_ar_wptr        ),

--- a/target/synth/carfield_synth_wrap.sv
+++ b/target/synth/carfield_synth_wrap.sv
@@ -117,9 +117,6 @@ module carfield_synth_wrap
   output logic [SlinkNumChan-1:0]                     slink_rcv_clk_o,
   input  logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_i,
   output logic [SlinkNumChan-1:0][SlinkNumLanes-1:0]  slink_o,
-  // HyperBus clocks
-  input  logic                                        hyp_clk_phy_i,
-  input  logic                                        hyp_rst_phy_ni,
   // HyperBus interface
   output logic [HypNumPhys-1:0][HypNumChips-1:0]      hyper_cs_no,
   output logic [HypNumPhys-1:0]                       hyper_ck_o,
@@ -202,8 +199,6 @@ module carfield_synth_wrap
     .slink_rcv_clk_o           ,
     .slink_i                   ,
     .slink_o                   ,
-    .hyp_clk_phy_i             ,
-    .hyp_rst_phy_ni            ,
     .hyper_cs_no               ,
     .hyper_ck_o                ,
     .hyper_ck_no               ,

--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -182,8 +182,6 @@ module carfield_soc_fixture;
     .slink_rcv_clk_o            ( slink_rcv_clk_o           ),
     .slink_i                    ( slink_i                   ),
     .slink_o                    ( slink_o                   ),
-    .hyp_clk_phy_i              ( clk                       ),
-    .hyp_rst_phy_ni             ( rst_n                     ),
     .hyper_cs_no                ( hyper_cs_n_wire           ),
     .hyper_ck_o                 ( hyper_ck_wire             ),
     .hyper_ck_no                ( hyper_ck_n_wire           ),


### PR DESCRIPTION
The hyperbus peripheral is currently receiving its clock from an external port (which is not connected in carfield_chip at the moment!). However, the interfaces are supposed to be synchronous to the peripheral clock. Therefore this PR removes those external ports and connects the hyperbus peripheral to the peripheral clock domain/reset domain.