### PR TITLE
Draft: Add domains' SW reset test

### DIFF
--- a/sw/include/car_util.h
+++ b/sw/include/car_util.h
@@ -1,0 +1,52 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Alessandro Ottaviano <aottaviano@iis.ee.ethz.ch>
+//
+
+#ifndef __CAR_UTIL_H
+#define __CAR_UTIL_H
+
+#include "util.h"
+#include "car_memory_map.h"
+#include "io.h"
+
+// val = 1: isolation
+// val = 0: deisolation
+void set_domain_isolation(uint32_t val, uint32_t isolate_offset, uint32_t isolate_status_offset) {
+    writew(val, CAR_SOC_CTRL_BASE_ADDR + isolate_offset);
+    fence();
+    while (readw(CAR_SOC_CTRL_BASE_ADDR + isolate_status_offset) != val)
+	;
+}
+
+void set_clk_enable_domain(uint32_t val, uint32_t offset) {
+    writew(val, CAR_SOC_CTRL_BASE_ADDR + offset);
+    fence();
+}
+
+void set_reset_n_domain(uint32_t val, uint32_t offset) {
+    writew(val, CAR_SOC_CTRL_BASE_ADDR + offset);
+    fence();
+}
+
+void domain_sw_reset(uint32_t isolate_offset, uint32_t isolate_offset_status, uint32_t clk_en_offset,
+		     uint32_t reset_n_offset) {
+
+    set_domain_isolation(1, isolate_offset, isolate_offset_status);
+
+    // Disable domain's clock
+    writew(0, CAR_SOC_CTRL_BASE_ADDR + clk_en_offset);
+
+    // Reset cycle
+    writew(0, CAR_SOC_CTRL_BASE_ADDR + reset_n_offset);
+    writew(1, CAR_SOC_CTRL_BASE_ADDR + reset_n_offset);
+
+    // Re-enable domain's clock
+    writew(1, CAR_SOC_CTRL_BASE_ADDR + clk_en_offset);
+
+    set_domain_isolation(0, isolate_offset, isolate_offset_status);
+}
+
+#endif

--- a/sw/tests/hostd/addressability_test.c
+++ b/sw/tests/hostd/addressability_test.c
@@ -9,6 +9,7 @@
 #include "dif/clint.h"
 #include "dif/uart.h"
 #include "io.h"
+#include "car_util.h"
 #include "params.h"
 #include "regs/cheshire.h"
 #include "util.h"
@@ -91,7 +92,7 @@ int probe_range_lfsr_wrwr(volatile uintptr_t from, volatile uintptr_t to, int sa
         // write
         lfsr = lfsr_64bits(lfsr, lfsr_byte_feedback);
         writed(lfsr, addr);
-        asm volatile("fence" : : : "memory");
+        fence();
         // read
         if (lfsr != readd(addr))
             return 1;
@@ -119,7 +120,7 @@ int probe_range_lfsr_wwrr(volatile uintptr_t from, volatile uintptr_t to, int sa
         addr += incr;
     }
 
-    asm volatile("fence" : : : "memory");
+    fence();
 
     // read
     addr = from;

--- a/sw/tests/hostd/domain_reset_test.c
+++ b/sw/tests/hostd/domain_reset_test.c
@@ -1,0 +1,25 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Nicole Narr <narrn@student.ethz.ch>
+// Christopher Reinwardt <creinwar@student.ethz.ch>
+//
+// Simple payload to test bootmodes
+
+#include "dif/clint.h"
+#include "dif/uart.h"
+#include "params.h"
+#include "regs/cheshire.h"
+#include "regs/soc_ctrl.h"
+#include "util.h"
+#include "car_util.h"
+
+int main(void) {
+
+    // Isolate domain
+    domain_sw_reset(CARFIELD_SAFETY_ISLAND_ISOLATE_REG_OFFSET, CARFIELD_SAFETY_ISLAND_ISOLATE_STATUS_REG_OFFSET,
+                    CARFIELD_SAFETY_ISLAND_CLK_EN_REG_OFFSET, CARFIELD_SAFETY_ISLAND_RST_REG_OFFSET);
+
+        return 0;
+}


### PR DESCRIPTION

- [x] Write startup code to de-isolate, reset and enable the clock in the subdomains
