### PR TITLE
treewide: Bump security island dependency

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -348,7 +348,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: cce5a6e0bacba31374109969adcd7abb0f70f7ec
+    revision: 5ce64a6225e971c1e00ece29aa485f23a31aa7b2
     version: null
     source:
       Git: https://github.com/alsaqr-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 4239b2a510d65aa110bcc8a070e434cabd1a8b9a } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 60e768a3ef29f47339e31674d497293f5a768893 } # branch: atops
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: a746000f9dc9965e1351186905b59bca36edef57 } # branch: yt/carfield-integration
-  opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: cce5a6e0bacba31374109969adcd7abb0f70f7ec } # branch: yt/hartid
+  opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 5ce64a6225e971c1e00ece29aa485f23a31aa7b2 } # branch: carfield
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/sw/tests/hostd/mbox_test.c
+++ b/sw/tests/hostd/mbox_test.c
@@ -25,22 +25,15 @@ int main(int argc, char const *argv[]) {
     asm volatile("csrw  mstatus, %0\n" : : "r"(global_irq_en  ));     // Set global interrupt enable in CVA6 csr
     asm volatile("csrw  mie, %0\n"     : : "r"(external_irq_en));     // Set external interrupt enable in CVA6 csr
     // PLIC setup
-    mmio_region_t plic_base_addr = mmio_region_from_addr(0x04000000);
+    mmio_region_t plic_base_addr = mmio_region_from_addr(0x03008000);
     t = dif_rv_plic_init(plic_base_addr, &plic0);
     t = dif_rv_plic_irq_set_priority(&plic0, mbox_id, prio);
     t = dif_rv_plic_irq_set_enabled(&plic0, mbox_id, 0, kDifToggleEnabled);
-    writed(0xBAADC0DE, 0x40000008);
-    writed(0xBAADC0DE, 0x40000010);
-    writed(0xBAADC0DE, 0x40000014);
-    writed(0xBAADC0DE, 0x40000018);
-    writed(0xBAADC0DE, 0x4000001C);
-    a = readd(0x40000008);
-    b = readd(0x40000010);
-    c = readd(0x40000014);
-    d = readd(0x40000018);
-    e = readd(0x4000001C);
-    if( a == 0xBAADC0DE && b == 0xBAADC0DE && c == 0xBAADC0DE && d == 0xBAADC0DE && e == 0xBAADC0DE)
-	writed(0x00000001, 0x40000020);    // ring doorbell if mailbox is accessible
+    writed(0xBAADC0DE, 0x40000B80);
+    a = readd(0x40000B80);
+    if( a == 0xBAADC0DE )
+      writed(0x00000001, 0x40000B04);    // ring doorbell if mailbox is accessible
+      writed(0x00000001, 0x40000B0c);
     wfi();
     return 0;
 }

--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -380,11 +380,11 @@ module carfield_soc_fixture;
      };
      //dm_ot::dtm_op_status_e op;
      automatic int dmi_wait_cycles = 10;
-     $info(" JTAG Preloading start time");
+     $display("[JTAG SECD] JTAG Preloading Starting");
      jtag_secd_dbg.wait_idle(300);
      jtag_secd_dbg.get_idcode(idcode);
      // Check Idcode
-     $display(" IDCode = %h", idcode);
+     $display("[JTAG SECD] IDCode = %h", idcode);
      // Activate Debug Module
      jtag_secd_dbg.write_dmi(dm_ot::DMControl, 32'h0000_0001);
      do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
@@ -405,22 +405,23 @@ module carfield_soc_fixture;
      jtag_secd_dbg.write_dmi(dm_ot::SBCS, sbcs);
      do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
      while (sbcs.sbbusy);
-     $display("======== Preload data to Secd SRAM ========");
      // Start writing to SRAM
      foreach (secd_sections[addr]) begin
-       $display("Writing %h with %0d words", addr << 2, secd_sections[addr]); // word = 8 bytes here
+       $display("[JTAG SECD] Writing %h with %0d words", addr << 2, secd_sections[addr]); // word = 8 bytes here
        jtag_secd_dbg.write_dmi(dm_ot::SBAddress0, (addr << 2));
        do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
        while (sbcs.sbbusy);
        for (int i = 0; i < secd_sections[addr]; i++) begin
-         $display(" -- Word %0d/%0d", i, secd_sections[addr]);
+         if (i%100 == 0)
+           $display("[JTAG SECD] loading: %0d/100%%", i*100/secd_sections[addr]);
          jtag_secd_dbg.write_dmi(dm_ot::SBData0, secd_memory[addr + i]);
          // Wait until SBA is free to write next 32 bits
          do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
          while (sbcs.sbbusy);
        end
+       $display("[JTAG SECD] loading: 100/100%%");
      end
-    $display("======== Preloading finished ========");
+    $display("[JTAG SECD] Preloading finished");
     // Preloading finished. Can now start executing
     sbcs.sbreadonaddr = 0;
     sbcs.sbreadondata = 0;
@@ -440,7 +441,7 @@ module carfield_soc_fixture;
     };
     //dm_ot::dtm_op_status_e op;
     automatic int dmi_wait_cycles = 10;
-    $info("======== Waking up Secd using JTAG ========");
+    $display("[JTAG SECD] Waking up Secd");
     // Initialize the dm module again, otherwise it will not work
     debug_secd_module_init();
     do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
@@ -473,7 +474,7 @@ module carfield_soc_fixture;
     do jtag_secd_dbg.read_dmi(dm_ot::SBCS, sbcs, dmi_wait_cycles);
 
     while (sbcs.sbbusy);
-    $info("======== Wait for Completion ========");
+    $display("[JTAG SECD] Wait for Completion");
   endtask
 
   task load_secd_binary;
@@ -483,12 +484,12 @@ module carfield_soc_fixture;
 
     // Read ELF
     void'(read_elf(binary));
-    $display("Reading %s", binary);
+    $display("[JTAG SECD] Reading %s", binary);
 
     while (get_section(section_addr, section_len)) begin
       // Read Sections
       automatic int num_words = (section_len + AxiWideBeWidth_ib - 1)/AxiWideBeWidth_ib;
-      $display("Reading section %x with %0d words", section_addr, num_words);
+      $display("[JTAG SECD] Reading section %x with %0d words", section_addr, num_words);
 
       secd_sections[section_addr >> AxiWideByteOffset_ib] = num_words;
       buffer = new[num_words * AxiWideBeWidth_ib];

--- a/tb/carfield_tb.sv
+++ b/tb/carfield_tb.sv
@@ -52,6 +52,8 @@ module tb_carfield_soc;
         0: begin      // JTAG
           // Security Island
           if (secd_preload_elf != "") begin
+            repeat(10000)
+              @(posedge fix.clk);
             fix.debug_secd_module_init();
             fix.load_secd_binary(secd_preload_elf);
             fix.jtag_secd_data_preload();


### PR DESCRIPTION
**[Security island]**
- [x] Fix spurious latch (Fixes #55)
- [x] Update bootrom code
- [x] Reduced SRAM and FLASH (304KiB each flash bank,156KiB of SRAM)
- [x] Modify debug rom to adapt to the new coreID
- [x] Modify mailbox test code to align with new mailbox

**[Carfield]**
- [x] Update security island mailbox test
- [x] Update security island JTAG testbench tasks