### PR TITLE
Bender.yml: Remove entry from nonfree list

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -73,7 +73,6 @@ sources:
     files:
       - nonfree/intel16/sourcecode/tc_clk.sv
       - nonfree/intel16/sourcecode/tc_sram.sv
-      - nonfree/intel16/sourcecode/tc_pads.sv
       - nonfree/intel16/sourcecode/generic_delay_D4_O1_3P750_CG0.sv
       - nonfree/intel16/sourcecode/tc_sram_impl.sv
       - nonfree/intel16/sourcecode/sync.sv


### PR DESCRIPTION
A module was removed in the nonfree repository, hence we remove it from here as well.