### PR TITLE
Bender: Bump spatz

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -497,7 +497,7 @@ packages:
     - common_cells
     - register_interface
   spatz:
-    revision: 3072b05ee2d983fb47c04ad58ff509b2f8522434
+    revision: 51cc9153cac6dd717aaa0247249255464e6091bb
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:spatz/spatz.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ dependencies:
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
-  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: 3072b05ee2d983fb47c04ad58ff509b2f8522434 } # branch: michaero/carfield
+  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: 51cc9153cac6dd717aaa0247249255464e6091bb } # branch: michaero/carfield
   bus_err_unit:       { git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git,          rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 } # branch: main
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.30.0                               }
 

--- a/hw/cfg/spatz_carfield.hjson
+++ b/hw/cfg/spatz_carfield.hjson
@@ -33,14 +33,14 @@
         // Timing parameters
         timing: {
             lat_comp_fp32: 2,
-            lat_comp_fp64: 3,
+            lat_comp_fp64: 4,
             lat_comp_fp16: 1,
             lat_comp_fp16_alt: 1,
             lat_comp_fp8: 0,
             lat_comp_fp8_alt: 0,
             lat_noncomp: 1,
             lat_conv: 2,
-            lat_sdotp: 3,
+            lat_sdotp: 4,
             fpu_pipe_config: "BEFORE"
             xbar_latency: "CUT_ALL_PORTS",
 


### PR DESCRIPTION
* Add new and fix existing SW tests
* Fix undriven nets
* Fix race condition between vector store and load
* Decouple scatter-gather index width from SEW
* Fix hazard detection of indexed memory operations
* Propagate testmode signal