### PR TITLE
Bump Spatz to version

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -497,8 +497,8 @@ packages:
     - common_cells
     - register_interface
   spatz:
-    revision: 51cc9153cac6dd717aaa0247249255464e6091bb
-    version: null
+    revision: d9138f1dd271b12a34a670416e925cf25efac1a6
+    version: 0.4.1
     source:
       Git: git@iis-git.ee.ethz.ch:spatz/spatz.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ dependencies:
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
-  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: 51cc9153cac6dd717aaa0247249255464e6091bb } # branch: michaero/carfield
+  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    version: 0.4.1                                }
   bus_err_unit:       { git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git,          rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 } # branch: main
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.30.0                               }
 


### PR DESCRIPTION
This PR bumps Spatz to the latest version, fixing some timing issues:

* [Remove register_offload_req parameter](https://iis-git.ee.ethz.ch/spatz/spatz/-/commit/caacaf5f3fdc9b265bedf506ac1597af318e9fc0)
* [Pipeline the core response](https://iis-git.ee.ethz.ch/spatz/spatz/-/commit/24c3968564c06d460cda12d514d9114f28d52da3)
* [Add the dp-fdotp kernel](https://iis-git.ee.ethz.ch/spatz/spatz/-/commit/4d3edc29d76dfea5af4dd562d29f64ee07e90520)
* [Add the dp-faxpy kernel](https://iis-git.ee.ethz.ch/spatz/spatz/-/commit/d9138f1dd271b12a34a670416e925cf25efac1a6)