### PR TITLE
cheshire_cfg: Set number of cores to 2

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -82,8 +82,8 @@ packages:
     - common_cells
     - obi
   axi_riscv_atomics:
-    revision: 97dcb14ef057cbe5bd70dda2060b5bb9e7e04c6d
-    version: 0.7.0
+    revision: c3c3f2b65071841035c4e081c61c9b7be801d749
+    version: 0.8.1
     source:
       Git: https://github.com/pulp-platform/axi_riscv_atomics.git
     dependencies:
@@ -134,7 +134,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 7514252a9502737be3412078da371f3ce4207dbe
+    revision: d2a2a5b0b68383f227c12bd80f63a282a2c8ce4f
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -166,8 +166,8 @@ packages:
     - common_cells
     - register_interface
   clint:
-    revision: e1357c1d0edddde458aec58363473605f51e539e
-    version: 0.1.0
+    revision: d5390a805c20f9226758a152ba1645f61da73349
+    version: 0.2.0
     source:
       Git: https://github.com/pulp-platform/clint.git
     dependencies:
@@ -211,7 +211,7 @@ packages:
     - fpnew
     - tech_cells_generic
   cva6:
-    revision: bf806ffa1385876ab70b28df488fafe7ea573a7f
+    revision: 3a628bf7585b3a3a0c3d205fbce8f998ac492fed
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.1                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.10                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 7514252a9502737be3412078da371f3ce4207dbe } # branch: aottaviano/carfield
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: d2a2a5b0b68383f227c12bd80f63a282a2c8ce4f } # branch: nwistoff/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 2adb7271438cdb96c19fbaf3e2a6bf89ffeee568 } # branch: lv/phys_in_use
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: b0501345b1741fa96b781ef5d845026fec036fd2 } # branch: param_banks

--- a/carfield.mk
+++ b/carfield.mk
@@ -21,9 +21,9 @@ VOPTARGS ?=
 
 # Interrupt configuration in cheshire
 # CLINT interruptible harts
-CLINTCORES     := 3
+CLINTCORES     := 4
 # PLIC interruptible harts
-PLICCORES      := 6
+PLICCORES      := 8
 # PLIC number of input interrupts
 PLIC_NUM_INTRS := 89
 

--- a/carfield.mk
+++ b/carfield.mk
@@ -90,7 +90,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= a51afe8cd67a47b83df79e1d0f53d5a8cf22371d
+CAR_NONFREE_COMMIT ?= 717358edc2da9e31f4b24622086f6bc756344237
 
 ## Clone the non-free verification IP for the Carfield TB
 car-nonfree-init:

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -238,7 +238,7 @@ assign car_periph_intrs = {
 
 // Mailbox unit
 
-localparam int unsigned CheshireNumIntHarts = 1 + Cfg.DualCore;
+localparam int unsigned CheshireNumIntHarts = Cfg.NumCores;
 localparam int unsigned SafedNumIntHarts    = 1;
 localparam int unsigned SecdNumIntHarts     = 1;
 

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -222,7 +222,7 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
                                    // [0x7000_0000, 0x8000_0000) is CIE
   Cva6ExtCieOnTop   : 1,
   // Harts
-  DualCore          : 0,  // Only one core, but rest of config allows for two
+  NumCores          : 2,
   CoreMaxTxns       : 8,
   CoreMaxTxnsPerId  : 4,
   // Interrupt parameters


### PR DESCRIPTION
Add a second self-invalidation-coherent cva6 core. Tasks:
- [x] Merge multicore support in Cheshire https://github.com/pulp-platform/cheshire/pull/56
- [x] Bump Cheshire
- [x] Set the number of cores in `carfield_pkg`
- [x] Update `CLINTCORES` and `PLICCORES` in `cheshire.mk`