### PR TITLE
Clock gate and isolate Islands on reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,21 @@ work/
 /.venv/
 /logs/
 /working_dir/
+/uart
 
+# sw auto-generated
 sw/tests/bare-metal/safed/*.h
+sw/tests/bare-metal/pulpd/*.h
+
+# ctags, etags ...
+TAGS
+
+# symlinks
+/cheshire
+/opentitan
+/pulp_cluster
+/safety_island
+/spatz
 
 # Created by https://www.toptal.com/developers/gitignore/api/python
 # Edit at https://www.toptal.com/developers/gitignore?templates=python

--- a/carfield.mk
+++ b/carfield.mk
@@ -292,11 +292,12 @@ $(PULPD_ROOT)/regression-tests: $(PULPD_ROOT)
 	$(MAKE) -C $(PULPD_ROOT) regression-tests
 
 # For independent boot of an island, we allow to compile the binary standalone.
-.PHONY: safed-sw-build pulpd-sw-build
+.PHONY: safed-sw-build
 safed-sw-build:
 	. $(CAR_ROOT)/scripts/safed-env.sh; \
 	$(MAKE) safed-sw-all
 
+.PHONY: pulpd-sw-build
 pulpd-sw-build:
 	. $(CAR_ROOT)/scripts/pulpd-env.sh; \
 	$(MAKE) pulpd-sw-all
@@ -342,6 +343,7 @@ SPYGLASS_DEFS += $(synth_defs)
 
 ## @section Carfield SoC Utilities
 
+.PHONY:lint
 ## Run Spyglass Lint on the entire RTL
 lint:
 	$(MAKE) -C scripts lint bender_defs="$(SPYGLASS_DEFS)" bender_targs="$(SPYGLASS_TARGS)" > make.log

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -725,7 +725,7 @@ assign domain_clk_div_changed[L2DomainIdx]         = car_regs_reg2hw.l2_clk_div_
 
 assign domain_clk_en[PeriphDomainIdx]     = car_regs_reg2hw.periph_clk_en.q;
 assign domain_clk_en[SafedDomainIdx]      = car_regs_reg2hw.safety_island_clk_en.q;
-// secure boot mode forces security island to come up concurently with host domain. Furthermore, it
+// secure boot mode forces security island to come up concurrently with host domain. Furthermore, it
 // cannot be disabled by design
 assign domain_clk_en[SecdDomainIdx]       = car_regs_reg2hw.security_island_clk_en.q | secure_boot_i;
 assign domain_clk_en[IntClusterDomainIdx] = car_regs_reg2hw.pulp_cluster_clk_en.q;
@@ -779,7 +779,8 @@ assign slave_isolate_req[EthernetSlvIdx]       = car_regs_reg2hw.periph_isolate.
 // Hyperbus isolation follows writes to the peripheral isolate registers in `carfield_reg_top`
 assign hyper_isolate_req                       = car_regs_reg2hw.periph_isolate.q;
 assign slave_isolate_req[PeriphsSlvIdx]        = car_regs_reg2hw.periph_isolate.q;
-assign security_island_isolate_req             = car_regs_reg2hw.security_island_isolate.q;
+assign security_island_isolate_req             = car_regs_reg2hw.security_island_isolate.q
+                                                 && !secure_boot_i;
 
 always_comb begin : gen_assign_isolated_responses
   slave_isolated = '0;

--- a/hw/regs/carfield_reg_top.sv
+++ b/hw/regs/carfield_reg_top.sv
@@ -570,7 +570,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_safety_island_isolate (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -597,7 +597,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_security_island_isolate (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -624,7 +624,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_pulp_cluster_isolate (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -651,7 +651,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_spatz_cluster_isolate (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -894,7 +894,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_safety_island_clk_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -921,7 +921,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_security_island_clk_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -948,7 +948,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_pulp_cluster_clk_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),
@@ -975,7 +975,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_spatz_cluster_clk_en (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),

--- a/hw/regs/carfield_regs.csv
+++ b/hw/regs/carfield_regs.csv
@@ -15,10 +15,10 @@ PULP_CLUSTER_RST,1,rw,hro,0,0,"PULP Cluster reset -active high, inverted in HW-"
 SPATZ_CLUSTER_RST,1,rw,hro,0,0,"Spatz Cluster reset -active high, inverted in HW-"
 L2_RST,1,rw,hro,0,0,"L2 reset -active high, inverted in HW-"
 PERIPH_ISOLATE,1,rw,hro,0,0,Periph Domain  AXI isolate
-SAFETY_ISLAND_ISOLATE,1,rw,hro,0,0,Safety Island AXI isolate
-SECURITY_ISLAND_ISOLATE,1,rw,hro,0,0,Security Island AXI isolate
-PULP_CLUSTER_ISOLATE,1,rw,hro,0,0,PULP Cluster AXI isolate
-SPATZ_CLUSTER_ISOLATE,1,rw,hro,0,0,Spatz Cluster AXI isolate
+SAFETY_ISLAND_ISOLATE,1,rw,hro,0,1,Safety Island AXI isolate
+SECURITY_ISLAND_ISOLATE,1,rw,hro,0,1,Security Island AXI isolate
+PULP_CLUSTER_ISOLATE,1,rw,hro,0,1,PULP Cluster AXI isolate
+SPATZ_CLUSTER_ISOLATE,1,rw,hro,0,1,Spatz Cluster AXI isolate
 L2_ISOLATE,1,rw,hro,0,0,L2 AXI isolate
 PERIPH_ISOLATE_STATUS,1,rw,hwo,0,0,Periph Domain AXI isolate status
 SAFETY_ISLAND_ISOLATE_STATUS,1,rw,hwo,0,0,Safety Island AXI isolate status
@@ -27,10 +27,10 @@ PULP_CLUSTER_ISOLATE_STATUS,1,rw,hwo,0,0,PULP Cluster AXI isolate status
 SPATZ_CLUSTER_ISOLATE_STATUS,1,rw,hwo,0,0,Spatz Cluster AXI isolate status
 L2_ISOLATE_STATUS,1,rw,hwo,0,0,L2 AXI isolate status
 PERIPH_CLK_EN,1,rw,hro,0,1,Periph Domain clk gate enable
-SAFETY_ISLAND_CLK_EN,1,rw,hro,0,1,Safety Island clk gate enable
-SECURITY_ISLAND_CLK_EN,1,rw,hro,0,1,Security Island clk gate enable
-PULP_CLUSTER_CLK_EN,1,rw,hro,0,1,PULP Cluster clk gate enable
-SPATZ_CLUSTER_CLK_EN,1,rw,hro,0,1,Spatz Cluster clk gate enable
+SAFETY_ISLAND_CLK_EN,1,rw,hro,0,0,Safety Island clk gate enable
+SECURITY_ISLAND_CLK_EN,1,rw,hro,0,0,Security Island clk gate enable
+PULP_CLUSTER_CLK_EN,1,rw,hro,0,0,PULP Cluster clk gate enable
+SPATZ_CLUSTER_CLK_EN,1,rw,hro,0,0,Spatz Cluster clk gate enable
 L2_CLK_EN,1,rw,hro,0,1,Shared L2 memory clk gate enable
 PERIPH_CLK_SEL,2,rw,hro,0,2,"Periph Domain pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
 SAFETY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Safety Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"

--- a/hw/regs/carfield_regs.hjson
+++ b/hw/regs/carfield_regs.hjson
@@ -192,7 +192,7 @@
       desc: "Safety Island AXI isolate",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "0",
+      resval: "1",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -203,7 +203,7 @@
       desc: "Security Island AXI isolate",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "0",
+      resval: "1",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -214,7 +214,7 @@
       desc: "PULP Cluster AXI isolate",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "0",
+      resval: "1",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -225,7 +225,7 @@
       desc: "Spatz Cluster AXI isolate",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "0",
+      resval: "1",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -324,7 +324,7 @@
       desc: "Safety Island clk gate enable",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "1",
+      resval: "0",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -335,7 +335,7 @@
       desc: "Security Island clk gate enable",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "1",
+      resval: "0",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -346,7 +346,7 @@
       desc: "PULP Cluster clk gate enable",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "1",
+      resval: "0",
       hwqe: "0",
       fields: [
         { bits: "0:0" }
@@ -357,7 +357,7 @@
       desc: "Spatz Cluster clk gate enable",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "1",
+      resval: "0",
       hwqe: "0",
       fields: [
         { bits: "0:0" }

--- a/sw/include/car_util.h
+++ b/sw/include/car_util.h
@@ -188,35 +188,40 @@ void car_reset_domain(enum car_rst rst)
     car_set_isolate(rst, CAR_ISOLATE_DISABLE);
 }
 
+void car_enable_domain(enum car_rst rst)
+{
+    car_enable_clk(car_clkd_from_rstd(rst));
+    car_set_isolate(rst, CAR_ISOLATE_DISABLE);
+}
+
+void car_disable_domain(enum car_rst rst)
+{
+    car_disable_clk(car_clkd_from_rstd(rst));
+    car_set_isolate(rst, CAR_ISOLATE_ENABLE);
+}
+
 // De-isolate and ungate domains at startup. In non-secure boot mode, only the host domain is
 // de-isolated and ungated after POR. In secure boot mode, both the host domain and the security
 // domain are de-isolated and ungated after POR. Note that L2 and peripheral domain are always-on
 // after POR.
-void car_init_deisolate_ungate_domains_after_por()
+void car_enable_all_domains()
 {
     // Safety Island
-    car_enable_clk(car_clkd_from_rstd(CAR_SAFETY_RST));
-    car_set_isolate(CAR_SAFETY_RST, CAR_ISOLATE_DISABLE);
+    car_enable_domain(CAR_SAFETY_RST);
 
     // Security Island
-    car_enable_clk(car_clkd_from_rstd(CAR_SECURITY_RST));
-    car_set_isolate(CAR_SECURITY_RST, CAR_ISOLATE_DISABLE);
+    car_enable_domain(CAR_SECURITY_RST);
 
     // PULP Island
-    car_enable_clk(car_clkd_from_rstd(CAR_PULP_RST));
-    car_set_isolate(CAR_PULP_RST, CAR_ISOLATE_DISABLE);
+    car_enable_domain(CAR_PULP_RST);
 
     // Spatz Island
-    car_enable_clk(car_clkd_from_rstd(CAR_SPATZ_RST));
-    car_set_isolate(CAR_SPATZ_RST, CAR_ISOLATE_DISABLE);
+    car_enable_domain(CAR_SPATZ_RST);
 }
 
 void car_init_start()
 {
-    // TODO: init constructors list
-
-    // De-isolate and enable clock for domains from host
-    car_init_deisolate_ungate_domains_after_por();
+    car_enable_all_domains();
 }
 
 void car_init_stop()

--- a/sw/include/car_util.h
+++ b/sw/include/car_util.h
@@ -188,6 +188,43 @@ void car_reset_domain(enum car_rst rst)
     car_set_isolate(rst, CAR_ISOLATE_DISABLE);
 }
 
+// De-isolate and ungate domains at startup. In non-secure boot mode, only the host domain is
+// de-isolated and ungated after POR. In secure boot mode, both the host domain and the security
+// domain are de-isolated and ungated after POR. Note that L2 and peripheral domain are always-on
+// after POR.
+void car_init_deisolate_ungate_domains_after_por()
+{
+    // Safety Island
+    car_enable_clk(car_clkd_from_rstd(CAR_SAFETY_RST));
+    car_set_isolate(CAR_SAFETY_RST, CAR_ISOLATE_DISABLE);
+
+    // Security Island
+    car_enable_clk(car_clkd_from_rstd(CAR_SECURITY_RST));
+    car_set_isolate(CAR_SECURITY_RST, CAR_ISOLATE_DISABLE);
+
+    // PULP Island
+    car_enable_clk(car_clkd_from_rstd(CAR_PULP_RST));
+    car_set_isolate(CAR_PULP_RST, CAR_ISOLATE_DISABLE);
+
+    // Spatz Island
+    car_enable_clk(car_clkd_from_rstd(CAR_SPATZ_RST));
+    car_set_isolate(CAR_SPATZ_RST, CAR_ISOLATE_DISABLE);
+}
+
+void car_init_start()
+{
+    // TODO: init constructors list
+
+    // De-isolate and enable clock for domains from host
+    car_init_deisolate_ungate_domains_after_por();
+}
+
+void car_init_stop()
+{
+    // TODO: init destructors list
+}
+
+
 // Safety Island offload
 void prepare_safed_boot () {
 

--- a/sw/tests/bare-metal/hostd/addressability_test.c
+++ b/sw/tests/bare-metal/hostd/addressability_test.c
@@ -139,6 +139,9 @@ int probe_range_lfsr_wwrr(volatile uintptr_t from, volatile uintptr_t to, int sa
 
 int main(void) {
 
+    // Init the HW
+    car_init_start();
+
     int errors = 0;
 
     // Probe an address range with pseudo-random values and read after each write

--- a/sw/tests/bare-metal/hostd/helloworld.c
+++ b/sw/tests/bare-metal/hostd/helloworld.c
@@ -12,8 +12,13 @@
 #include "dif/uart.h"
 #include "params.h"
 #include "util.h"
+#include "car_util.h"
 
 int main(void) {
+
+    // Init the HW
+    car_init_start();
+
     char str[] = "Hello World!\r\n";
     uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);

--- a/sw/tests/bare-metal/hostd/pulp-offload.c
+++ b/sw/tests/bare-metal/hostd/pulp-offload.c
@@ -20,6 +20,9 @@
 
 int main(void)
 {
+  // Init the HW
+  car_init_start();
+
   char str[] = "Cluster boot.\r\n";
   uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
   uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);

--- a/sw/tests/bare-metal/hostd/safed_offloader_blocking.c
+++ b/sw/tests/bare-metal/hostd/safed_offloader_blocking.c
@@ -22,7 +22,10 @@ extern int load_safed_payload ();
 
 int main(void)
 {
-	// Here we assume that the offloader has to poll a status register to catch the end of
+        // Init the HW
+        car_init_start();
+
+        // Here we assume that the offloader has to poll a status register to catch the end of
 	// computation of the Safety Island. Therefore, the offloading is blocking.
 	uint32_t ret = safed_offloader_blocking();
 

--- a/sw/tests/bare-metal/hostd/sw_rst_seq.c
+++ b/sw/tests/bare-metal/hostd/sw_rst_seq.c
@@ -76,8 +76,9 @@ int main(void)
     car_reset_domain(CAR_L2_RST);
 
     // Security Island
-    // We can't access anything so this needs to be checked manually
-    car_reset_domain(CAR_SECURITY_RST);
+    // We can't access anything so this needs to be checked manually In secure boot mode, the
+    // security island can't be software resetted, which is why we disable this for now
+    // car_reset_domain(CAR_SECURITY_RST);
 
     return 0;
 }

--- a/sw/tests/bare-metal/hostd/sw_rst_seq.c
+++ b/sw/tests/bare-metal/hostd/sw_rst_seq.c
@@ -20,6 +20,9 @@
 
 int main(void)
 {
+    // Init the HW
+    car_init_start();
+
     // Safety Island
 
     // We write a bunch of bytes to the safety island's boot register and check

--- a/sw/tests/bare-metal/hostd/system_timer_test.c
+++ b/sw/tests/bare-metal/hostd/system_timer_test.c
@@ -27,8 +27,8 @@
 	} \
     } while (0)
 
-#define DUMMY_TIMER_CNT_GOLDEN_MIN 8050
-#define DUMMY_TIMER_CNT_GOLDEN_MAX 8280
+#define DUMMY_TIMER_CNT_GOLDEN_MIN 8000
+#define DUMMY_TIMER_CNT_GOLDEN_MAX 9000
 
 int main(void) {
 

--- a/sw/tests/bare-metal/hostd/system_timer_test.c
+++ b/sw/tests/bare-metal/hostd/system_timer_test.c
@@ -13,6 +13,7 @@
 #include "regs/cheshire.h"
 #include "regs/system_timer.h"
 #include "util.h"
+#include "car_util.h"
 
 // TODO: This test is really brittle. Its only purpose is to test timer accesses when the timer is
 // configured in freerunning mode and check if the value is within a sensible range. A better test
@@ -30,6 +31,9 @@
 #define DUMMY_TIMER_CNT_GOLDEN_MAX 8280
 
 int main(void) {
+
+    // Init the HW
+    car_init_start();
 
     // Reset system timer
     writed(1, CAR_SYSTEM_TIMER_BASE_ADDR + TIMER_RESET_LO_OFFSET);

--- a/tb/carfield_tb.sv
+++ b/tb/carfield_tb.sv
@@ -50,6 +50,11 @@ module tb_carfield_soc;
 
   logic [63:0] unused;
 
+  // timing format for $display("...$t..", $realtime)
+  initial begin : timing_format
+    $timeformat(-9, 0, "ns", 9);
+  end : timing_format
+
   // Cheshire standalone binary execution
   initial begin
     // Fetch plusargs or use safe (fail-fast) defaults

--- a/tb/carfield_tb.sv
+++ b/tb/carfield_tb.sv
@@ -78,7 +78,7 @@ module tb_carfield_soc;
             // Cheshire
             is_dram = uvm_re_match("dram",chs_preload_elf);
             if(~is_dram) begin
-              $display("Wait the hyperram");
+              $display("[TB] %t - Wait for HyperRAM", $realtime);
               repeat(120000)
                 @(posedge fix.clk);
             end
@@ -126,8 +126,10 @@ module tb_carfield_soc;
     if (safed_preload_elf != "") begin
 
       $display("Enabling clock and de-isolating Safety Island after PoR for standalone test...");
+      $display("[TB] %t - Enabling safety island clock for stand-alone tests ", $realtime);
       // Clock island after PoR
       fix.safed_vip.axi_write_32(SafetyIslandClkEnRegAddr, 32'h1);
+      $display("[TB] %t - De-isolate safety island for stand-alone tests ", $realtime);
       // De-isolate island after PoR
       fix.safed_vip.axi_write_32(SafetyIslandIsolateRegAddr, 32'h0);
       //do begin
@@ -168,7 +170,7 @@ module tb_carfield_soc;
     case(secd_boot_mode)
       0: begin
         // Go in secure bootmode to let the Security island be de-isolated and clocked after PoR
-        $display("Entering secure boot mode for Security island after PoR (clock enable and de-isolation handled in HW)");
+        $display("[TB] %t - Entering secure boot mode for Security island after PoR (clock enable and de-isolation handled in HW)", $realtime);
         fix.set_secure_boot(CarfieldSecureBootOn);
         fix.secd_vip.set_secd_boot_mode(2'b00);
         if (secd_preload_elf != "") begin
@@ -183,7 +185,7 @@ module tb_carfield_soc;
         end
       end 1: begin
         // Go in secure bootmode to let the Security island be de-isolated and clocked after PoR
-        $display("Entering secure boot mode for Security island after PoR (clock enable and de-isolation handled in HW)");
+        $display("[TB] %t - Entering secure boot mode for Security island after PoR (clock enable and de-isolation handled in HW)", $realtime);
         fix.set_secure_boot(CarfieldSecureBootOn);
         fix.secd_vip.set_secd_boot_mode(2'b01);
         fix.secd_vip.spih_norflash_preload(secd_flash_vmem);


### PR DESCRIPTION
**[EDIT]** @alex96295:
- [x] Update default reset value for isolation and clock gating of carfield's domains (currently, the peripheral domain is left out from isolation/clock gating. It might cause Linux boot complications so we should consider leaving it on by default.)
- [ ] ~~Create a `system_init()` function with `constructor` attribute to initialize isolation and clock gating of domains in non-secure bootmode~~ -> in a future PR


Fixes #71  
Fixes #126 
Fixes #46 
