### PR TITLE
Point to open-source deps - 1

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -116,8 +116,8 @@ packages:
     - common_cells
     - register_interface
   can_bus:
-    revision: 230222cc568b49b39a3385b12edaf680657bc69d
-    version: 0.0.1
+    revision: 0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379
+    version: null
     source:
       Git: git@github.com:AlSaqr-platform/can_bus.git
     dependencies: []
@@ -359,10 +359,10 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 245d92fe49dc6be32afe3bfb6a133778002d4880
+    revision: a9dadf1d9134a91a9a80c977d8c8cea024ccfe65
     version: null
     source:
-      Git: https://github.com/alsaqr-platform/opentitan.git
+      Git: https://github.com/pulp-platform/opentitan.git
     dependencies:
     - axi
   opentitan_peripherals:

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,12 +17,12 @@ dependencies:
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: b0501345b1741fa96b781ef5d845026fec036fd2 } # branch: param_banks
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 78c7e4b188151c7790bb1422b9aeeb28f5e0b588 } # branch: yt/rapidrecovery
-  opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 245d92fe49dc6be32afe3bfb6a133778002d4880 } # branch: carfield
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: a9dadf1d9134a91a9a80c977d8c8cea024ccfe65 } # branch: carfield-soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
-  can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
+  can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379 } # branch: pulp
   spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: v0.4.3                                   }
   bus_err_unit:       { git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git,          rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 } # branch: main
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.31.1                               }


### PR DESCRIPTION
In this PR, we point to the open-source upstream of:

- [x] `opentitan` (`carfield-soc` dev branch) 
- [x] `can_bus` (`pulp` dev branch)