### PR TITLE
Rename incorrect hyperbus reset bidirectional IO signal

### DIFF
--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -113,7 +113,7 @@ module carfield_soc_fixture;
   wire [NumPhys-1:0]                pad_hyper_ck;
   wire [NumPhys-1:0]                pad_hyper_ckn;
   wire [NumPhys-1:0]                pad_hyper_rwds;
-  wire [NumPhys-1:0]                pad_hyper_reset;
+  wire [NumPhys-1:0]                pad_hyper_resetn;
   wire [NumPhys-1:0][7:0]           pad_hyper_dq;
 
   carfield      #(

--- a/tb/vip_carfield_soc.sv
+++ b/tb/vip_carfield_soc.sv
@@ -42,7 +42,7 @@ module vip_carfield_soc
   wire [HypNumPhys-1:0]                  pad_hyper_ck,
   wire [HypNumPhys-1:0]                  pad_hyper_ckn,
   wire [HypNumPhys-1:0]                  pad_hyper_rwds,
-  wire [HypNumPhys-1:0]                  pad_hyper_reset,
+  wire [HypNumPhys-1:0]                  pad_hyper_resetn,
   wire [HypNumPhys-1:0][7:0]             pad_hyper_dq,
   // External virtual AXI ports
   input  axi_slv_ext_req_t [NumAxiExtSlvPorts-1:0] axi_slvs_req,
@@ -95,7 +95,7 @@ module vip_carfield_soc
         .CSNeg    ( pad_hyper_csn[i][j] ),
         .CK       ( pad_hyper_ck[i]     ),
         .CKNeg    ( pad_hyper_ckn[i]    ),
-        .RESETNeg ( pad_hyper_reset[i]  )
+        .RESETNeg ( pad_hyper_resetn[i]  )
       );
     end
   end
@@ -194,7 +194,7 @@ module vip_carfield_soc_tristate import carfield_pkg::*; # (
   wire [HypNumPhys-1:0]                  pad_hyper_ck,
   wire [HypNumPhys-1:0]                  pad_hyper_ckn,
   wire [HypNumPhys-1:0]                  pad_hyper_rwds,
-  wire [HypNumPhys-1:0]                  pad_hyper_reset,
+  wire [HypNumPhys-1:0]                  pad_hyper_resetn,
   wire [HypNumPhys-1:0][7:0]             pad_hyper_dq
 );
 
@@ -234,7 +234,7 @@ module vip_carfield_soc_tristate import carfield_pkg::*; # (
       .I   ( hyper_reset_no[i]  ),
       .O   (                    ),
       .PEN (                    ),
-      .PAD ( pad_hyper_reset[i] )
+      .PAD ( pad_hyper_resetn[i] )
     );
     for (genvar j = 0; j < 8; j++) begin : gen_hyper_dq
       pad_functional_pd padinst_hyper_dqio0  (


### PR DESCRIPTION
The signal is active low (convention: `*_n` or `*n` in the signal name), but the corresponding I/O pad (bidirectional) was not following said convention.