### PR TITLE
Bender: Bump `axi_rt` AXI real-time unit

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -30,14 +30,6 @@ packages:
     - common_cells
     - common_verification
     - tech_cells_generic
-  axi-rt:
-    revision: a14e1926f1ccedbc8fc739444ce86c1e09195fe5
-    version: 0.0.2-beta
-    source:
-      Git: git@iis-git.ee.ethz.ch:bslk/axi-rt.git
-    dependencies:
-    - axi
-    - common_cells
   axi2mem:
     revision: 6973e0434d26ba578cdb4aa69c26c1facd1a3f15
     version: null
@@ -90,6 +82,15 @@ packages:
     - axi
     - common_cells
     - common_verification
+  axi_rt:
+    revision: 6c00b92158e9359a60f07081be1d806d3a05fdbf
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/axi_rt.git
+    dependencies:
+    - axi
+    - common_cells
+    - register_interface
   axi_slice:
     revision: a4f72bc21ac4d7da631e8309d9f8d0c34b735c23
     version: 1.1.4
@@ -134,16 +135,16 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 834ea0dc2109c03c472c6afbdf7d1ae10503cb6a
+    revision: 6c314fa41f56174edd88f85a899d44b9107d174a
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
     dependencies:
     - apb_uart
     - axi
-    - axi-rt
     - axi_llc
     - axi_riscv_atomics
+    - axi_rt
     - axi_vga
     - bus_err_unit
     - clic
@@ -188,8 +189,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: 0989ff73d0315922791bf42137c0ce0cbb4a76ca
-    version: 1.30.0
+    revision: 53b0b58af2db5bd3c850a7038fae170ed78326bb
+    version: 1.31.1
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.1                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.10                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 834ea0dc2109c03c472c6afbdf7d1ae10503cb6a } # branch: nwistoff/carfield
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 6c314fa41f56174edd88f85a899d44b9107d174a } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 2adb7271438cdb96c19fbaf3e2a6bf89ffeee568 } # branch: lv/phys_in_use
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: b0501345b1741fa96b781ef5d845026fec036fd2 } # branch: param_banks
@@ -25,7 +25,7 @@ dependencies:
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 230222cc568b49b39a3385b12edaf680657bc69d }
   spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: v0.4.3                                   }
   bus_err_unit:       { git: git@iis-git.ee.ethz.ch:carfield/bus_err_unit.git,          rev: 47a6436dc4b4b7f4a44f7786033b22c6d01530b2 } # branch: main
-  common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.30.0                               }
+  common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.31.1                               }
 
 
 workspace:

--- a/carfield.mk
+++ b/carfield.mk
@@ -30,6 +30,10 @@ PLIC_NUM_INTRS := 89
 # Serial Link configuration in cheshire
 SERIAL_LINK_NUM_BITS := 16
 
+# AXI Real-Time unit configuration in Carfield
+AXIRT_NUM_MGRS := 10
+AXIRT_NUM_SUBS := 2
+
 # Cheshire
 CHS_ROOT ?= $(shell $(BENDER) path cheshire)
 # Include cheshire's makefrag only if the dependency was cloned
@@ -241,7 +245,10 @@ spatz-hw-init:
 ## This target has a prerequisite, i.e. the PLIC configuration must be chosen before generating the
 ## hardware.
 chs-hw-init: update_plic update_serial_link
-	$(MAKE) chs-hw-all
+	# Note: We use `-B` as AXI RT doesn't currently have a `regenerate` PHONY target to always
+	# trigger register regeneration when the value of the variables passed to its makefrag
+	# changes.
+	$(MAKE) -B chs-hw-all
 
 .PHONY: chs-sim-init
 ## Downloads verification IPs for SPI and I2C from cheshire and used by Carfield.

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -340,8 +340,10 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
   // GPIOs
   GpioInputSyncs    : 1,
   // AXI RT
-  AxiRtNumPending   : 16,
-  AxiRtWBufferDepth : 16,
+  AxiRtNumPending     : 16,
+  AxiRtWBufferDepth   : 16,
+  AxiRtNumAddrRegions : 2,
+  AxiRtCutPaths       : 1,
   // All non-set values should be zero
   default: '0
 };


### PR DESCRIPTION
- [x] Bump cheshire: point to standalone, open-source AXI RT
- [x] Bump common_cells to `v1.31.1`