### PR TITLE
Bender: Bump `pulp_cluster` dependency

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -11,8 +11,8 @@ overrides:
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.12                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
   idma:                 { git: "https://github.com/pulp-platform/idma.git"                , rev:     437ffa9                                }
-  hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be   }
-  scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: f7b51416f3c407e4c31e9c016616d57aae2687bd   }
+  hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: fac03040e4901daad29c141fc481f7c5d3758e99   }
+  scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix
   clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: bed98f8 }
   fpnew:                { git: "https://github.com/pulp-platform/cvfpu.git"               , rev: pulp-v0.1.3 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -261,7 +261,7 @@ packages:
     - hwpe-stream
     - l2_tcdm_hybrid_interco
   hier-icache:
-    revision: a7e3f4e4c7fe607bcd6b9d94db77f612fd6ef6be
+    revision: fac03040e4901daad29c141fc481f7c5d3758e99
     version: null
     source:
       Git: https://github.com/pulp-platform/hier-icache.git
@@ -273,8 +273,8 @@ packages:
     - scm
     - tech_cells_generic
   hwpe-ctrl:
-    revision: 3d9b9bea7b98df24e6b235408364521a1a27d561
-    version: 1.7.2
+    revision: b7857919ea14b586901ff4282ad7749a3d50501e
+    version: null
     source:
       Git: https://github.com/pulp-platform/hwpe-ctrl.git
     dependencies:
@@ -382,7 +382,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 201453dbcedc8f7235b2723363356ba5845e5120
+    revision: 78c7e4b188151c7790bb1422b9aeeb28f5e0b588
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -411,7 +411,7 @@ packages:
     - tech_cells_generic
     - timer_unit
   redmule:
-    revision: 3797413e5f190c2a86185ab6d8b12af365051b1e
+    revision: 886ad5ecf5fd908e0c0b278c22914a76a704eda3
     version: null
     source:
       Git: https://github.com/pulp-platform/redmule.git
@@ -482,7 +482,7 @@ packages:
     - tech_cells_generic
     - timer_unit
   scm:
-    revision: f7b51416f3c407e4c31e9c016616d57aae2687bd
+    revision: 74426dee36f28ae1c02f7635cf844a0156145320
     version: null
     source:
       Git: https://github.com/pulp-platform/scm.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 2adb7271438cdb96c19fbaf3e2a6bf89ffeee568 } # branch: lv/phys_in_use
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: b0501345b1741fa96b781ef5d845026fec036fd2 } # branch: param_banks
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 201453dbcedc8f7235b2723363356ba5845e5120 } # branch: yt/rapidrecovery
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 78c7e4b188151c7790bb1422b9aeeb28f5e0b588 } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/alsaqr-platform/opentitan.git,          rev: 245d92fe49dc6be32afe3bfb6a133778002d4880 } # branch: carfield
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }

--- a/bender-common.mk
+++ b/bender-common.mk
@@ -11,6 +11,7 @@ common_targs += -t mchan
 common_targs += -t spatz
 common_targs += -t integer_cluster
 common_targs += -t cv32e40p_use_ff_regfile
+common_targs += -t scm_use_fpga_scm
 common_targs += -t cv64a6_imafdcsclic_sv39
 common_targs += -t rtl
 
@@ -18,4 +19,5 @@ common_targs += -t rtl
 common_defs += -D FEATURE_ICACHE_STAT
 common_defs += -D PRIVATE_ICACHE
 common_defs += -D HIERARCHY_ICACHE_32BIT
+common_defs += -D ICAHE_USE_FF
 common_defs += -D CLUSTER_ALIAS

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1384,7 +1384,7 @@ pulp_cluster #(
   .AXI_ID_IN_WIDTH                ( IntClusterAxiIdInWidth    ),
   .AXI_ID_OUT_WIDTH               ( IntClusterAxiIdOutWidth   ),
   .LOG_DEPTH                      ( LogDepth                  ),
-  .BaseAddr                       ( IntClusterBaseAddr        ),
+  .BaseAddr                       ( IntClusterBase            ),
   .CdcSynchStages                 ( SyncStages                )
 ) i_integer_cluster            (
   .clk_i                       ( pulp_clk                                  ),
@@ -1392,7 +1392,7 @@ pulp_cluster #(
   .pwr_on_rst_ni               ( pulp_pwr_on_rst_n                         ),
   .ref_clk_i                   ( rt_clk_i                                  ),
   .pmu_mem_pwdn_i              ( '0                                        ),
-  .base_addr_i                 ( '0                                        ),
+  .base_addr_i                 ( IntClusterBase[31:28]                     ),
   .test_mode_i                 ( test_mode_i                               ),
   .cluster_id_i                ( IntClusterIndex                           ),
   .en_sa_boot_i                ( car_regs_reg2hw.pulp_cluster_boot_enable  ),

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -424,9 +424,6 @@ localparam int unsigned IntClusterMaxUniqId = 1;
 localparam int unsigned IntClusterNumEoc = 1;
 localparam logic [ 5:0] IntClusterIndex = (PulpHartIdOffs >> 5);
 localparam logic [CarfieldCfgDefault.AddrWidth-1:0] IntClusterInternalSize = 'h0040_0000;
-// verilog_lint: waive-start line-length
-localparam logic [CarfieldCfgDefault.AddrWidth-1:0] IntClusterBaseAddr = IntClusterBase - IntClusterIndex*IntClusterInternalSize;
-// verilog_lint: waive-stop line-length
 
 /*******************************/
 /* Narrow Parameters: A32, D32 */


### PR DESCRIPTION
- [x] Bumps the PULP cluster to a version that is not using latches in the icache and in the HWPE control register file. This bumps `hier-icache`, `scm`, `redmule`, and `hwpe-ctrl`
- [x] Solve runtime issues allowing the cores' stacks to be located in the cluster TCDM, and not in the L2.