### PR TITLE
Add secure boot pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ Follow these steps to launch a Carfield simulation:
 * Compile tests for Carfield. Tests resides in `sw/tests`.
 
   ```
-  # Compile Safety Island standalone software
-  source ./scripts/safed-env.sh
-  make safed-sw-build
-  # Compile Integer cluster standalone software
-  source ./scripts/pulpd-env.sh
-  make pulpd-sw-build
-  # Compile Cheshire SW
   make car-sw-build
   ```
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Follow these steps to launch a Carfield simulation:
 * Compile tests for Carfield. Tests resides in `sw/tests`.
 
   ```
-  // Compile Safety Island standalone software
+  # Compile Safety Island standalone software
   source ./scripts/safed-env.sh
   make safed-sw-build
-  // Compile Integer cluster standalone software
+  # Compile Integer cluster standalone software
   source ./scripts/pulpd-env.sh
   make pulpd-sw-build
-  // Compile Cheshire SW
+  # Compile Cheshire SW
   make car-sw-build
   ```
 

--- a/carfield.mk
+++ b/carfield.mk
@@ -255,7 +255,7 @@ chs-sw-build: chs-sw-all
 
 .PHONY: car-sw-build
 ## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
-car-sw-build: chs-sw-build car-sw-all
+car-sw-build: chs-sw-build safed-sw-build pulpd-sw-build car-sw-all
 
 .PHONY: car-init
 ## Shortcut to initialize carfield with all the targets described above.
@@ -281,8 +281,13 @@ $(PULPD_ROOT)/regression-tests: $(PULPD_ROOT)
 
 # For independent boot of an island, we allow to compile the binary standalone.
 .PHONY: safed-sw-build pulpd-sw-build
-safed-sw-build: safed-sw-all
-pulpd-sw-build: pulpd-sw-all
+safed-sw-build:
+	. $(CAR_ROOT)/scripts/safed-env.sh; \
+	$(MAKE) safed-sw-all
+
+pulpd-sw-build:
+	. $(CAR_ROOT)/scripts/pulpd-env.sh; \
+	$(MAKE) pulpd-sw-all
 
 ############
 # RTL LINT #

--- a/carfield.mk
+++ b/carfield.mk
@@ -90,7 +90,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 717358edc2da9e31f4b24622086f6bc756344237
+CAR_NONFREE_COMMIT ?= 728f16e60e6785217a144146cc390b56c44cdb4c
 
 ## Clone the non-free verification IP for the Carfield TB
 car-nonfree-init:

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1579,7 +1579,7 @@ secure_subsystem_synth_wrap #(
   .rst_ni           ( security_rst_n  ),
   .pwr_on_rst_ni    ( security_pwr_on_rst_n ),
   .fetch_en_i       ( car_regs_reg2hw.security_island_fetch_enable ),
-  .bootmode_i       ( '0              ),
+  .bootmode_i       ( bootmode_ot_i   ),
   .test_enable_i    ( test_mode_i     ),
   .irq_ibex_i       ( secd_mbox_intr  ), // from hostd or safed
    // JTAG port

--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -73,6 +73,8 @@ module carfield_soc_fixture;
   logic uart_hostd_tx;
   logic uart_hostd_rx;
 
+  logic secure_boot;
+
   logic uart_secd_tx;
   logic uart_secd_rx;
 
@@ -149,6 +151,7 @@ module carfield_soc_fixture;
     .jtag_safety_island_tdo_o   ( jtag_safed_tdo            ),
     .bootmode_ot_i              ( '0                        ),
     .bootmode_safe_isln_i       ( boot_mode_safed           ),
+    .secure_boot_i              ( secure_boot               ),
     .uart_tx_o                  ( uart_hostd_tx             ),
     .uart_rx_i                  ( uart_hostd_rx             ),
     .uart_ot_tx_o               ( uart_secd_tx              ),
@@ -377,6 +380,8 @@ module carfield_soc_fixture;
   ) secd_vip (
     .clk_vip   (),
     .rst_n_vip (),
+    // secure boot enabled
+    .secure_boot  ( secure_boot      ),
     // UART interface
     .uart_tx      ( uart_secd_tx     ),
     .uart_rx      ( uart_secd_rx     ),

--- a/tb/vip_security_island_soc.sv
+++ b/tb/vip_security_island_soc.sv
@@ -24,6 +24,8 @@ module vip_security_island_soc
 ) (
   output logic clk_vip,
   output logic rst_n_vip,
+  // secure boot enabled
+  output logic secure_boot,
   // UART interface
   input logic  uart_tx,
   output logic uart_rx,
@@ -55,6 +57,13 @@ module vip_security_island_soc
     @(posedge rst_n);
     @(posedge clk);
   endtask
+
+  /////////////////
+  // Secure boot //
+  /////////////////
+
+  // TODO: secure boot emulation mode is currently not tested
+  assign secure_boot = 1'b0;
 
   //////////
   // JTAG //


### PR DESCRIPTION
Adds (experimental) secure boot mode as pin. This feature make sure that the security island comes up at the roughly the same time as the cva6 and can't be clockgates/isolated. In summary this should allow a secure boot flow to be implemented in software