### PR TITLE
Point to open-source deps - 2

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -113,19 +113,6 @@ packages:
     source:
       Git: git@github.com:AlSaqr-platform/can_bus.git
     dependencies: []
-  car_l2:
-    revision: 0143fb296e3614adf8894ff7335cc3f9b92783bd
-    version: null
-    source:
-      Git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git
-    dependencies:
-    - axi
-    - axi_riscv_atomics
-    - common_cells
-    - common_verification
-    - redundancy_cells
-    - register_interface
-    - tech_cells_generic
   cheshire:
     revision: 99b654154f3c60db08d33d07e0885b44b5d846c1
     version: null
@@ -213,6 +200,19 @@ packages:
     - axi
     - common_cells
     - fpnew
+    - tech_cells_generic
+  dyn_mem:
+    revision: 480590062742230dc9bd4050358a15b4747bdf34
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/dyn_spm.git
+    dependencies:
+    - axi
+    - axi_riscv_atomics
+    - common_cells
+    - common_verification
+    - redundancy_cells
+    - register_interface
     - tech_cells_generic
   ethernet:
     revision: 2b6f916d3f25f9829713faeef6adc799e861744c

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 99b654154f3c60db08d33d07e0885b44b5d846c1 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
-  car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
+  dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: d0771928a2b850272c7a3d1b2a4a767bfb7c30a9 } # branch: michaero/carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: de93f2001ee0a6fca1dc11f6dd95119d8e6aadfb } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc

--- a/hw/l2_wrap.sv
+++ b/hw/l2_wrap.sv
@@ -9,7 +9,7 @@
 module l2_wrap
   import carfield_pkg::*;
   import axi_pkg::*;
-  import car_l2_pkg::*;
+  import dyn_mem_pkg::*;
 #(
   parameter cheshire_pkg::cheshire_cfg_t Cfg = CarfieldCfgDefault,
   /// AXI Ports settings
@@ -30,7 +30,7 @@ module l2_wrap
   parameter type         l2_ecc_reg_req_t = logic,
   parameter type         l2_ecc_reg_rsp_t = logic,
   /// Mapping rules
-  parameter int unsigned NumRules   = car_l2_pkg::NUM_MAP_TYPES * NumPort,
+  parameter int unsigned NumRules   = dyn_mem_pkg::NUM_MAP_TYPES * NumPort,
   /// L2 Memory settings
   parameter int unsigned L2MemSize  = 2**20,
   /// Non-changable parameters
@@ -154,21 +154,21 @@ typedef struct packed {
 } map_rule_t;
 
 localparam map_rule_t [NumRules-1:0] MappingRules = '{
-  '{idx       : car_l2_pkg::INTERLEAVE  ,
+  '{idx       : dyn_mem_pkg::INTERLEAVE  ,
     start_addr: L2Port0Base             ,
     end_addr  : L2Port0Base + L2MemSize},
-  '{idx       : car_l2_pkg::NONE_INTER           ,
+  '{idx       : dyn_mem_pkg::NONE_INTER           ,
     start_addr: L2Port0NonInterlBase             ,
     end_addr  : L2Port0NonInterlBase + L2MemSize},
-  '{idx       : car_l2_pkg::INTERLEAVE ,
+  '{idx       : dyn_mem_pkg::INTERLEAVE ,
     start_addr: L2Port1Base            ,
     end_addr  : L2Port1Base + L2MemSize},
-  '{idx       : car_l2_pkg::NONE_INTER          ,
+  '{idx       : dyn_mem_pkg::NONE_INTER          ,
     start_addr: L2Port1NonInterlBase            ,
     end_addr  : L2Port1NonInterlBase + L2MemSize}
 };
 
-car_l2_top #(
+dyn_mem_top #(
   .NUM_PORT            ( NumPort         ),
   .AXI_ADDR_WIDTH      ( AxiAddrWidth    ),
   .AXI_DATA_WIDTH      ( AxiDataWidth    ),


### PR DESCRIPTION
In this PR, we bump to open source version of the (shared) dynamic scratchpad memory

- [x] `dyn_mem`