### PR TITLE
Integrate Ethernet IP

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -10,7 +10,7 @@ overrides:
   redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "482d2f5" } # branch: yt/rapidrecovery
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.12                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
-  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , rev:     437ffa9                                }
+  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , rev: 73716841c8a4c0dfb68164a4a4017212db7cbcfd   }
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: fac03040e4901daad29c141fc481f7c5d3758e99   }
   scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix

--- a/Bender.lock
+++ b/Bender.lock
@@ -213,6 +213,14 @@ packages:
     - common_cells
     - fpnew
     - tech_cells_generic
+  ethernet:
+    revision: 8b0cee7ef143b4c637a875664881232ac1c518a5
+    version: null
+    source:
+      Git: git@iis-git.ee.ethz.ch:bslk/iis-ethernet/fe-ethernet.git
+    dependencies:
+    - axi
+    - common_verification
   event_unit_flex:
     revision: 53fb3a1093aaaedfe883739fd8a3155d601210bc
     version: null

--- a/Bender.lock
+++ b/Bender.lock
@@ -83,8 +83,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: 6c00b92158e9359a60f07081be1d806d3a05fdbf
-    version: null
+    revision: b243310dd33b31e4e2ca5229aac20df25cfc45d5
+    version: 0.0.0-alpha
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:
@@ -127,7 +127,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: c1012ae99118bdef4e8ce6b4a4730c2f94deb541
+    revision: 1b4e73e1e99d7fb452893385a979d548fa8524d5
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -310,7 +310,7 @@ packages:
       Git: git@github.com:pulp-platform/icache-intc.git
     dependencies: []
   idma:
-    revision: 437ffa9dac5dea0daccfd3e8ae604d4f6ae2cdf1
+    revision: 73716841c8a4c0dfb68164a4a4017212db7cbcfd
     version: null
     source:
       Git: https://github.com/pulp-platform/idma.git
@@ -434,8 +434,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: 3b2bf592100b769977c76e51812c55cd742882f6
-    version: 0.4.1
+    revision: d7693be4aef1fc7e7eb2b00b41c42e87d959866c
+    version: 0.4.2
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -25,6 +25,7 @@ dependencies:
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379 } # branch: pulp
   spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: v0.4.3                                   }
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.31.1                               }
+  ethernet:           { git: git@iis-git.ee.ethz.ch:bslk/iis-ethernet/fe-ethernet.git,  rev: 8b0cee7ef143b4c637a875664881232ac1c518a5 } # branch: aottaviano/carfield-dev
 
 
 workspace:

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,9 +10,9 @@ package:
     - "Robert Balas <balasr@iis.ee.ethz.ch>"
 
 dependencies:
-  register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.1                                }
+  register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.2                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.10                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: c1012ae99118bdef4e8ce6b4a4730c2f94deb541 } # branch: aottaviano/carfield
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 1b4e73e1e99d7fb452893385a979d548fa8524d5 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: v0.0.3                                   } 
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 83389a5b16df92df6e082728be53cd9c33ec8b8d } # branch: main

--- a/bender-synth.mk
+++ b/bender-synth.mk
@@ -15,3 +15,4 @@ synth_targs += -t cluster_standalone
 # bender defines
 synth_defs += -D SYNTHESIS
 synth_defs += -D EXCLUDE_PADFRAME
+synth_defs += -D TARGET_INTEL16_SIMPLE_DPM_RF

--- a/carfield.mk
+++ b/carfield.mk
@@ -97,7 +97,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= e245c845e29d183467e92c529058a36725b2eff5
+CAR_NONFREE_COMMIT ?= 5ed49a2b91a33f0fbbbca0ee63193ddc138c51b8
 
 ## Clone the non-free verification IP for the Carfield TB
 car-nonfree-init:

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -91,8 +91,9 @@ localparam int unsigned CarfieldNumTimerIntrs = CarfieldNumAdvTimerIntrs +
                         CarfieldNumAdvTimerEvents + CarfieldNumSysTimerIntrs;
 localparam int unsigned CarfieldNumWdtIntrs = 5;
 localparam int unsigned CarfieldNumCanIntrs = 1;
+localparam int unsigned CarfieldNumEthIntrs = 1;
 localparam int unsigned CarfieldNumPeriphsIntrs = CarfieldNumTimerIntrs +
-                        CarfieldNumWdtIntrs + CarfieldNumCanIntrs;
+                        CarfieldNumWdtIntrs + CarfieldNumCanIntrs + CarfieldNumEthIntrs;
 
 localparam int unsigned NumApbMst = 5;
 

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -241,8 +241,8 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
   AxiDataWidth      : 64,
   AxiUserWidth      : 10,  // {CACHE_PARTITIONING(5), ECC_ERROR(1), ATOPS(4)}
   AxiMstIdWidth     : 2,
-  AxiMaxMstTrans    : 8,
-  AxiMaxSlvTrans    : 8,
+  AxiMaxMstTrans    : 24,
+  AxiMaxSlvTrans    : 24,
   AxiUserAmoMsb     : 3, // Convention: lower AMO bits for cores, MSB for serial link
   AxiUserAmoLsb     : 0, // Convention: lower AMO bits for cores, MSB for serial link
   RegMaxReadTxns    : 8,
@@ -313,8 +313,8 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
   LlcSetAssoc       : 8,
   LlcNumLines       : 256,
   LlcNumBlocks      : 8,
-  LlcMaxReadTxns    : 8,
-  LlcMaxWriteTxns   : 8,
+  LlcMaxReadTxns    : 16,
+  LlcMaxWriteTxns   : 16,
   LlcAmoNumCuts     : 1,
   LlcAmoPostCut     : 1,
   LlcOutConnect     : 1,
@@ -339,9 +339,14 @@ localparam cheshire_cfg_t CarfieldCfgDefault = '{
   DmaConfMaxReadTxns  : 4,
   DmaConfMaxWriteTxns : 4,
   DmaConfAmoNumCuts   : 1,
+  DmaNumAxInFlight    : 16,
+  DmaMemSysDepth      : 8,
+  DmaJobFifoDepth     : 2,
+  DmaRAWCouplingAvail : 1,
   DmaConfAmoPostCut   : 1,
+  DmaConfEnableTwoD   : 1,
   // GPIOs
-  GpioInputSyncs    : 1,
+  GpioInputSyncs      : 1,
   // AXI RT
   AxiRtNumPending     : 16,
   AxiRtWBufferDepth   : 16,


### PR DESCRIPTION
- [x] Add ethernet IP from [this repository](https://iis-git.ee.ethz.ch/bslk/iis-ethernet/fe-ethernet/-/tree/aottaviano/carfield-dev?ref_type=heads)

**Note:** This version of the ethernet IP **does not** rely on a DMA to stream data to the shared scratchpad memory (in carfield, L2), and uses large buffering local to the IP. 

@mp-17 Before merging, have a look at the additional memory cuts (8 in total). Elaboration of `carfield_soc` passes, so the cuts are linked properly. I am tagging you to make you aware of the additions and the need to update the FP