### PR TITLE
carfield.mk: Set bender root

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -19,6 +19,8 @@ VIVADO   ?= vitis-2020.2 vivado
 TBENCH   ?= tb_carfield_soc
 VOPTARGS ?=
 
+BENDER_ROOT ?= $(CAR_ROOT)/.bender
+
 # Interrupt configuration in cheshire
 # CLINT interruptible harts
 CLINTCORES     := 4


### PR DESCRIPTION
Required by cheshire. This fixes the current re-initialisation of the dependencies with every make command, since `.chs_deps` can now be created (e.g. [here](https://iis-git.ee.ethz.ch/github-mirror/carfield/-/jobs/739933#L2949) this failed)