### PR TITLE
Makefile/questa: Switch to three-step flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ make car-hw-sim CHS_BOOTMODE=<chs_bootmode> CHS_PRELMODE=<chs_prelmode> CHS_BINA
 make car-hw-sim CHS_BOOTMODE=<chs_bootmode> CHS_PRELMODE=<chs_prelmode> CHS_IMAGE=<chs_binary_path>.car.memh PULPCL_BINARY=<pulpcl_binary> SPATZCL_BINARY=<spatzcl_binary> SECD_BINARY=<secd_binary_path> SAFED_BOOTMODE=<safed_bootmode> SAFED_BINARY=<safed_binary_path>
 ```
 
+### Debugging
+
+Per default, Questasim compilation is performance-optimised and simulation logging is disabled. To enable full visibility, logging, and the Questa GUI, set `DEBUG=1` when executing the steps above.
+
 ## License
 
 Unless specified otherwise in the respective file headers, all code checked into

--- a/carfield.mk
+++ b/carfield.mk
@@ -87,7 +87,7 @@ ifdef DEBUG
 	VSIM_FLAGS := $(QUESTA_FLAGS)
 	RUN_AND_EXIT := log -r /*; run -all
 else
-	VOPT_FLAGS := $(QUESTA_FLAGS) -O5
+	VOPT_FLAGS := $(QUESTA_FLAGS) -O5 +acc=p+tb_carfield_soc. +noacc=p+carfield.
 	VSIM_FLAGS := $(QUESTA_FLAGS) -c
 	RUN_AND_EXIT := run -all; exit
 endif

--- a/carfield.mk
+++ b/carfield.mk
@@ -16,7 +16,6 @@ CAR_HW_DIR  := $(CAR_ROOT)/hw
 BENDER   ?= bender
 QUESTA   ?= questa-2022.3
 VIVADO   ?= vitis-2020.2 vivado
-TBENCH   ?= tb_carfield_soc
 
 BENDER_ROOT ?= $(CAR_ROOT)/.bender
 
@@ -68,7 +67,6 @@ SPATZCL_BINARY  ?=
 
 # Default variable values for RTL simulation
 TBENCH         ?= tb_carfield_soc
-OPTARGS        ?=
 
 # Include bender targets and defines for common usage and synth verification
 # (the following includes are mandatory)

--- a/scripts/start_carfield.tcl
+++ b/scripts/start_carfield.tcl
@@ -7,13 +7,8 @@
 # Alessandro Ottaviano <aottaviano@iis.ee.ethz.ch>
 # Paul Scheffler <paulsc@iis.ee.ethz.ch>
 
-# Set voptargs only if not already set to make overridable.
-# Default on fast simulation flags.
-if {![info exists VOPTARGS]} {
-    set VOPTARGS "-O5 +acc=p+tb_carfield_soc. +noacc=p+carfield. +acc=r+stream_xbar"
-}
-
-set flags "-permissive -suppress 3009 -suppress 8386 -error 7"
+set flags ""
+if {[info exists VSIM_FLAGS]}     { append flags "${VSIM_FLAGS}" }
 
 set pargs ""
 if {[info exists CHS_BOOTMODE]}   { append pargs "+CHS_BOOTMODE=${CHS_BOOTMODE} "     }
@@ -26,7 +21,7 @@ if {[info exists SAFED_BOOTMODE]} { append pargs "+SAFED_BOOTMODE=${SAFED_BOOTMO
 if {[info exists SAFED_BINARY]}   { append pargs "+SAFED_BINARY=${SAFED_BINARY} "     }
 if {[info exists CHS_IMAGE]}      { append pargs "+CHS_IMAGE=${CHS_IMAGE} "           }
 
-eval "vsim -c ${TESTBENCH} -t 1ps -vopt -voptargs=\"${VOPTARGS}\"" ${pargs} ${flags}
+eval "vsim ${TESTBENCH}_opt -t 1ps" ${flags} ${pargs}
 
 set StdArithNoWarnings 1
 set NumericStdNoWarnings 1


### PR DESCRIPTION
The three-step flow is the recommended flow by questa. It provides more control and avoids re-optimising the design for each run. This is particularly critical for highly parallel simulations, since only one questa instance can run vopt at any time.

Note that this also removes accessibility default and logging by default for reduced CI footprint. Full accessibility, logging, and the gui can be activatied by setting `DEBUG=1`.