### PR TITLE
carfield_tb: Wait for UART before terminating sim

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -135,7 +135,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 6c314fa41f56174edd88f85a899d44b9107d174a
+    revision: 7a2d040f63b24ef2f980866490b072b92217d9b1
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.1                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.10                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 6c314fa41f56174edd88f85a899d44b9107d174a } # branch: aottaviano/carfield
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 7a2d040f63b24ef2f980866490b072b92217d9b1 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 4714902ecf23074fb20bb462db4c66d96cc631f5 } # branch: lv/phys_in_use
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: b0501345b1741fa96b781ef5d845026fec036fd2 } # branch: param_banks

--- a/tb/carfield_tb.sv
+++ b/tb/carfield_tb.sv
@@ -104,6 +104,9 @@ module tb_carfield_soc;
       // Eventually wait for HWRoT to end initialization anda ssert Ibex's fetch enable
       fix.passthrough_or_wait_for_secd_hw_init();
 
+      // Wait for the UART to finish reading the current byte
+      wait (fix.chs_vip.uart_reading_byte == 0);
+
       $finish;
     end
   end


### PR DESCRIPTION
see https://github.com/pulp-platform/cheshire/pull/67.
This lets the testbench defer termination until there is no active UART transmission.