### PR TITLE
ci: Add litmus tests

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -97,7 +97,7 @@ endif
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 768a777eb4376d3979cc81be9b1046ba70193383
+CAR_NONFREE_COMMIT ?= e245c845e29d183467e92c529058a36725b2eff5
 
 ## Clone the non-free verification IP for the Carfield TB
 car-nonfree-init:

--- a/carfield.mk
+++ b/carfield.mk
@@ -301,6 +301,37 @@ pulpd-sw-build:
 	. $(CAR_ROOT)/scripts/pulpd-env.sh; \
 	$(MAKE) pulpd-sw-all
 
+# Litmus tests
+LITMUS_WORK_DIR  := work-litmus
+LITMUS_TEST_LIST := $(LITMUS_WORK_DIR)/litmus-tests.list
+LITMUS_TESTS     := $(shell xargs printf '\n%s' < $(LITMUS_TEST_LIST) | cut -b 1-)
+
+$(LITMUS_WORK_DIR):
+	mkdir -p $(LITMUS_WORK_DIR)
+
+$(LITMUS_TEST_LIST): $(LITMUS_WORK_DIR)
+	basename -a `find $(LITMUS_DIR)/binaries/ -name "*.elf" | sed 's/\[/\\\[/g'` > $@
+
+$(LITMUS_TESTS):
+	$(MAKE) car-hw-sim CHS_BOOTMODE=0 CHS_PRELMODE=1 CHS_BINARY=$(LITMUS_DIR)/binaries/$@ | tee $(LITMUS_WORK_DIR)/$@.log
+
+$(LITMUS_WORK_DIR)/%.uart.log: %
+	sed -n 's/^# \[UART\] \(.*\S\)\s*$$/\1/p' $(LITMUS_WORK_DIR)/$<.log > $@
+
+$(LITMUS_WORK_DIR)/%.litmus.log: $(LITMUS_WORK_DIR)/%.uart.log
+	echo "Test $(basename $* .elf) Allowed" > $@
+	echo "Histogram" >> $@
+	cat $< >> $@
+	echo "" >> $@
+
+car-run-litmus-tests: $(LITMUS_TEST_LIST) $(addprefix $(LITMUS_WORK_DIR)/, $(addsuffix .litmus.log,$(LITMUS_TESTS)))
+	cat $^ > $(LITMUS_WORK_DIR)/litmus.log
+
+car-check-litmus-tests: $(LITMUS_WORK_DIR)/litmus.log
+	cd $(LITMUS_DIR) && LITMUS_LOG=$(CURDIR)/$(LITMUS_WORK_DIR)/litmus.log ci/compare_model.sh > $(CURDIR)/$(LITMUS_WORK_DIR)/compare.log
+	grep "Warning positive differences" $(LITMUS_WORK_DIR)/compare.log
+	! grep "Warning negative differences" $(LITMUS_WORK_DIR)/compare.log
+
 ############
 # RTL LINT #
 ############

--- a/sw/sw.mk
+++ b/sw/sw.mk
@@ -103,6 +103,17 @@ include $(CAR_SW_DIR)/tests/bare-metal/pulpd/sw.mk
 car-pulpd-sw-offload-tests:
 	$(call offload_tests_template,$(PULPD_HEADER_TARGETS),pulpd,$(CAR_ELFLOAD_PULPD_SRC_C),$(CAR_ELFLOAD_PULPD_PATH))
 
+# Litmus tests
+LITMUS_REPO := https://github.com/pulp-platform/CHERI-Litmus.git
+LITMUS_DIR  := $(CAR_SW_DIR)/tests/bare-metal/riscv-litmus-tests
+
+$(LITMUS_DIR):
+	git clone $(LITMUS_REPO) $(LITMUS_DIR)
+
+build-litmus-tests: $(LITMUS_DIR)
+	cd $(LITMUS_DIR)/frontend; ./make.sh
+	cd $(LITMUS_DIR)/binaries; ./make-riscv.sh ../tests/ cheshire 2
+
 # Benchmarks
 
 # Mibench


### PR DESCRIPTION
Add make targets to run and evaluate the litmus tests on carfield. Furthermore, add an optional job to run the litmus tests to the nonfree CI. _Note: https://github.com/pulp-platform/bender/pull/135, a bender release + update on the IIS machines are required for the litmus CI to pass._