### PR TITLE
Bender: Bump various IPs

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -10,7 +10,7 @@ overrides:
   redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "482d2f5" } # branch: yt/rapidrecovery
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
-  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , rev: 73716841c8a4c0dfb68164a4a4017212db7cbcfd   }
+  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.5.1                                  }
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: fac03040e4901daad29c141fc481f7c5d3758e99   }
   scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix

--- a/Bender.lock
+++ b/Bender.lock
@@ -310,8 +310,8 @@ packages:
       Git: git@github.com:pulp-platform/icache-intc.git
     dependencies: []
   idma:
-    revision: 73716841c8a4c0dfb68164a4a4017212db7cbcfd
-    version: null
+    revision: ca1b28816a3706be0bf9ce01378246d5346384f0
+    version: 0.5.1
     source:
       Git: https://github.com/pulp-platform/idma.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -127,7 +127,7 @@ packages:
     - register_interface
     - tech_cells_generic
   cheshire:
-    revision: 1b4e73e1e99d7fb452893385a979d548fa8524d5
+    revision: 4fbb6b0bcd15aaa2c1e60362821ad895f40b93ba
     version: null
     source:
       Git: https://github.com/pulp-platform/cheshire.git
@@ -321,7 +321,7 @@ packages:
     - register_interface
   irq_router:
     revision: d1d31350b24f3965b3a51e1bc96c71eb34e94db3
-    version: null
+    version: 0.0.1-beta.1
     source:
       Git: https://github.com/pulp-platform/irq_router.git
     dependencies:
@@ -511,8 +511,8 @@ packages:
     - riscv-dbg
     - tech_cells_generic
   tech_cells_generic:
-    revision: 298b7297d220ba2601d0f24f684f97ff32f61123
-    version: 0.2.12
+    revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
+    version: 0.2.13
     source:
       Git: https://github.com/pulp-platform/tech_cells_generic.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,7 +12,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.2                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.0-beta.10                       }
-  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 1b4e73e1e99d7fb452893385a979d548fa8524d5 } # branch: aottaviano/carfield
+  cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 4fbb6b0bcd15aaa2c1e60362821ad895f40b93ba } # branch: main
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: v0.0.3                                   } 
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: d6ab486b2777bf78c38b49352b5977565a272a58 } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 83389a5b16df92df6e082728be53cd9c33ec8b8d } # branch: main


### PR DESCRIPTION
* `cheshire` (main branch, `4fbb6b0`)
* `idma` (`v0.5.1`) -> Fixes non-synthesizable syntax
* `unbent` (`v0.1.5`)
* `tech_cells_generic` (`v0.2.13`)
* `irq_router` (`v0.0.1-beta.1`)