### PR TITLE
Point to open source deps - 3

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -497,10 +497,10 @@ packages:
     - common_cells
     - register_interface
   spatz:
-    revision: 526e8dc5a37201cee2256bd0439e8b9bbaa5724b
-    version: 0.4.3
+    revision: 664b583b76d73e1e3ef2faf88d94ffd8f8abda52
+    version: null
     source:
-      Git: git@iis-git.ee.ethz.ch:spatz/spatz.git
+      Git: https://github.com/pulp-platform/spatz.git
     dependencies:
     - axi
     - axi_riscv_atomics

--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ dependencies:
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379 } # branch: pulp
-  spatz:              { git: git@iis-git.ee.ethz.ch:spatz/spatz.git,                    rev: v0.4.3                                   }
+  spatz:              { git: https://github.com/pulp-platform/spatz.git,                rev: 664b583b76d73e1e3ef2faf88d94ffd8f8abda52 } # branch: main
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.31.1                               }
   ethernet:           { git: git@iis-git.ee.ethz.ch:bslk/iis-ethernet/fe-ethernet.git,  rev: 2b6f916d3f25f9829713faeef6adc799e861744c } # branch: aottaviano/carfield-dev
 

--- a/carfield.mk
+++ b/carfield.mk
@@ -248,6 +248,7 @@ car-hw-init: spatz-hw-init chs-hw-init
 
 .PHONY: spatz-hw-init
 spatz-hw-init:
+	$(MAKE) -C $(SPATZCL_ROOT) hw/ip/snitch/src/riscv_instr.sv
 	$(MAKE) -C $(SPATZCL_MAKEDIR) -B SPATZ_CLUSTER_CFG=$(CAR_HW_DIR)/cfg/spatz_carfield.hjson bootrom
 
 .PHONY: chs-hw-init


### PR DESCRIPTION
In this PR, we bump to open source version of spatz

- [x] `spatz`