### PR TITLE
Align boundary conditions with chip-level repo

### DIFF
--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -34,9 +34,9 @@ module carfield_soc_fixture;
   localparam cheshire_cfg_t DutCfg = carfield_pkg::CarfieldCfgDefault;
   `CHESHIRE_TYPEDEF_ALL(, DutCfg)
 
-  localparam time         ClkPeriodSys  = 5ns;
-  localparam time         ClkPeriodJtag = 20ns;
-  localparam time         ClkPeriodRtc  = 30518ns;
+  localparam time         ClkPeriodSys  = 10ns;
+  localparam time         ClkPeriodJtag = 40ns;
+  localparam time         ClkPeriodRtc  = 30520ns;
   localparam int unsigned RstCycles     = 5;
   localparam real         TAppl         = 0.1;
   localparam real         TTest         = 0.9;

--- a/tb/carfield_tb.sv
+++ b/tb/carfield_tb.sv
@@ -48,6 +48,9 @@ module tb_carfield_soc;
   string      secd_flash_vmem;
   logic       secd_boot_mode;
 
+  // hyperbus
+  localparam int unsigned HyperbusTburstMax = 32'h20009008;
+
   logic [63:0] unused;
 
   // timing format for $display("...$t..", $realtime)
@@ -70,6 +73,11 @@ module tb_carfield_soc;
 
     // Wait for reset
     fix.chs_vip.wait_for_reset();
+
+    // Writing max burst length in Hyperbus configuration registers to
+    // prevent the Verification IPs from triggering timing checks.
+    $display("[TB] INFO: Configuring Hyperbus through serial link.");
+    fix.chs_vip.slink_write_32(HyperbusTburstMax, 32'd128);
 
     if (chs_preload_elf != "" || chs_boot_hex != "") begin
       // When Cheshire is offloading to safety island, the latter should be set in passive preloaded


### PR DESCRIPTION
* Aligning RTC, System clock, and JTAG clock with values in chip-level testbench;
* Insert Hyperbus' max burst time config in testbenchl.