### PR TITLE
Parameterize default clock divider integer value for domains 

### DIFF
--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -583,6 +583,13 @@ logic [NumDomains-1:0] rsts_n;
 //    every target domain to use different clock frequencies.
 // 3. The internal clock gate of the clock divider is used to provide clock gating for the domain.
 
+localparam int unsigned DomainClkDivValue[NumDomains] = '{PeriphDomainClkDivValue     ,
+                                                          SafedDomainClkDivValue      ,
+                                                          SecdDomainClkDivValue       ,
+                                                          IntClusterDomainClkDivValue ,
+                                                          FPClusterDomainClkDivValue  ,
+                                                          L2DomainClkDivValue         };
+
 for (genvar i = 0; i < NumDomains; i++) begin : gen_domain_clock_mux
   clk_mux_glitch_free #(
     .NUM_INPUTS(3)
@@ -635,7 +642,7 @@ for (genvar i = 0; i < NumDomains; i++) begin : gen_domain_clock_mux
 
   clk_int_div #(
     .DIV_VALUE_WIDTH(DomainClkDivValueWidth),
-    .DEFAULT_DIV_VALUE(1),
+    .DEFAULT_DIV_VALUE(DomainClkDivValue[i]),
     .ENABLE_CLOCK_IN_RESET(1)
   ) i_clk_div (
     .clk_i          ( domain_clk[i]                  ),

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -32,6 +32,14 @@ typedef enum int {
   L2DomainIdx         = 'd5
 } carfield_domains_e;
 
+// Clock dividers integer value after PoR
+localparam int unsigned PeriphDomainClkDivValue     = 1;
+localparam int unsigned SafedDomainClkDivValue      = 1;
+localparam int unsigned SecdDomainClkDivValue       = 1;
+localparam int unsigned IntClusterDomainClkDivValue = 1;
+localparam int unsigned FPClusterDomainClkDivValue  = 1;
+localparam int unsigned L2DomainClkDivValue         = 1;
+
 typedef enum byte_bt {
   L2Port0SlvIdx      = 'd0,
   L2Port1SlvIdx      = 'd1,


### PR DESCRIPTION
* We make the default value of clock dividers controlling the clock of each domain parameterizable. 

* Change the value in `carfield_pkg.sv` to have a different clock div value after PoR

* At runtime, the divider value is configurable