### PR TITLE
hw: Change clk mux default value after PoR for L2 domain

### DIFF
--- a/hw/regs/carfield_reg_top.sv
+++ b/hw/regs/carfield_reg_top.sv
@@ -1176,7 +1176,7 @@ module carfield_reg_top #(
   prim_subreg #(
     .DW      (2),
     .SWACCESS("RW"),
-    .RESVAL  (2'h0)
+    .RESVAL  (2'h1)
   ) u_l2_clk_sel (
     .clk_i   (clk_i    ),
     .rst_ni  (rst_ni  ),

--- a/hw/regs/carfield_regs.csv
+++ b/hw/regs/carfield_regs.csv
@@ -37,7 +37,7 @@ SAFETY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Safety Island pll select (0 -> host pll, 1 -
 SECURITY_ISLAND_CLK_SEL,2,rw,hro,0,1,"Security Island pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
 PULP_CLUSTER_CLK_SEL,2,rw,hro,0,1,"PULP Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
 SPATZ_CLUSTER_CLK_SEL,2,rw,hro,0,1,"Spatz Cluster pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
-L2_CLK_SEL,2,rw,hro,0,0,"L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
+L2_CLK_SEL,2,rw,hro,0,1,"L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)"
 PERIPH_CLK_DIV_VALUE,24,rw,hro,1,1,Periph Domain clk divider value
 SAFETY_ISLAND_CLK_DIV_VALUE,24,rw,hro,1,1,Safety Island clk divider value
 SECURITY_ISLAND_CLK_DIV_VALUE,24,rw,hro,1,1,Security Island clk divider value

--- a/hw/regs/carfield_regs.hjson
+++ b/hw/regs/carfield_regs.hjson
@@ -434,7 +434,7 @@
       desc: "L2 Memory pll select (0 -> host pll, 1 -> alt PLL, 2 -> per pll)",
       swaccess: "rw",
       hwaccess: "hro",
-      resval: "0",
+      resval: "1",
       hwqe: "0",
       fields: [
         { bits: "1:0" }


### PR DESCRIPTION
* After PoR, when the chip receives host, alt and periph clock, the multiplexer for the L2 domain was set to distribute host clock by default. But L2 is supposed to work in alt clock domain by default. This can be changed dynamically during runtime