### PR TITLE
hw: Fix instantiation of reg cdc for external reg interface

### DIFF
--- a/hw/cheshire_wrap.sv
+++ b/hw/cheshire_wrap.sv
@@ -728,7 +728,7 @@ axi_id_remap            #(
 
 // Async reg interface:
 // See carfield_pkg.sv for indices referring to sync and async reg interfaces.
-for (genvar i = 0; i < Cfg.RegExtNumSlv - NumAsyncRegSlv; i++) begin : gen_ext_reg_async
+for (genvar i = 0; i < NumAsyncRegSlv; i++) begin : gen_ext_reg_async
   reg_cdc_src #(
     .CDC_KIND ( "cdc_4phase"              ),
     .req_t     ( cheshire_reg_ext_req_t   ),


### PR DESCRIPTION
* The for loop was iterating on the number of synchrnous interfaces instead of asyncrhonous, with the former set to 1. Hence, only one reg cdc for port 0 was generated!