### PR TITLE
carfield_fix: Skip OT boot if no secure boot

### DIFF
--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -431,7 +431,8 @@ module carfield_soc_fixture;
   ///////////////////
 
   task passthrough_or_wait_for_secd_hw_init();
-    if (secure_boot && i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable != lc_ctrl_pkg::On) begin
+    if ((secure_boot || !i_dut.car_regs_hw2reg.security_island_isolate_status.d) &&
+        i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable != lc_ctrl_pkg::On) begin
       $display("Wait for OT to boot...");
       wait (i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable == lc_ctrl_pkg::On);
     end

--- a/tb/carfield_fix.sv
+++ b/tb/carfield_fix.sv
@@ -431,7 +431,7 @@ module carfield_soc_fixture;
   ///////////////////
 
   task passthrough_or_wait_for_secd_hw_init();
-    if (i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable != lc_ctrl_pkg::On) begin
+    if (secure_boot && i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable != lc_ctrl_pkg::On) begin
       $display("Wait for OT to boot...");
       wait (i_dut.gen_secure_subsystem.i_security_island.u_RoT.u_rv_core_ibex.fetch_enable == lc_ctrl_pkg::On);
     end


### PR DESCRIPTION
Do not wait for OT to boot if `secure_boot` is deasserted. Lets TB terminate for test cases that do not initialise OT.