### PR TITLE
Bump PULP cluster to fix macro implementation

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -7,7 +7,7 @@ overrides:
   axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , version: 0.8.2 }
   apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
   register_interface:   { git: "https://github.com/pulp-platform/register_interface.git"  , version: 0.4.1 }
-  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "f206f5ecbfaa028f9eae6f0efaed9e34631d9171" } # branch: yt/rapidrecovery
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "f3b1bc9b2e816fe1b51147ceafa8955326d1b466" } # branch: yt/rapidrecovery
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
   idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.5.1                                  }

--- a/Bender.lock
+++ b/Bender.lock
@@ -375,7 +375,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 8356888056441d6cf5b94e348a0817264b9b1b8c
+    revision: 4d1558ac660ad445f62ffe44415ca6efc4240cf6
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -416,7 +416,7 @@ packages:
     - hwpe-stream
     - tech_cells_generic
   redundancy_cells:
-    revision: f206f5ecbfaa028f9eae6f0efaed9e34631d9171
+    revision: f3b1bc9b2e816fe1b51147ceafa8955326d1b466
     version: null
     source:
       Git: https://github.com/pulp-platform/redundancy_cells.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.4                                } 
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: cc541a6cf5995eea29dd255db68fbe7d2cd10af6 } # branch: michaero/carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 8356888056441d6cf5b94e348a0817264b9b1b8c } # branch: yt/rapidrecovery
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 4d1558ac660ad445f62ffe44415ca6efc4240cf6 } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 2c2830c055198f75fcd193f0e6772f70c2e2b036 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }


### PR DESCRIPTION
The PR provides:
* Replace latches in rapid recovery RF with FFs
* Bumps of the PULP cluster commits to kill the critical path in the DMR checkers (fixes time violations in synthesis, should fix it also in P&R, which is running at the moment)
* Bumps of the PULP cluster commits to try and fix the post-synthesis/layout simulations of the PULP cluster by using a structures-based AXI crossbar instead of the one using interfaces (this could be the reason why only AXI indeces are swapped in synthesis, but the address map is not changed accordingly)
* A lot of repetitive commits that must be properly squashed :)