### PR TITLE
hw: Minor fixes to carfield top

### DIFF
--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -1501,8 +1501,10 @@ end
 logic [spatz_cluster_pkg::NumCores-1:0] spatzcl_mbox_intr;
 // mti (machine timer interrupt) : hostd (RISC-V clint)
 // verilog_lint: waive-start line-length
-logic [spatz_cluster_pkg::NumCores-1:0] spatzcl_timer_intr = { chs_mti[FPClusterIntrHart1Idx], chs_mti[FPClusterIntrHart0Idx] };
+logic [spatz_cluster_pkg::NumCores-1:0] spatzcl_timer_intr;
 // verilog_lint: waive-stop line-length
+
+assign spatzcl_timer_intr = { chs_mti[FPClusterIntrHart1Idx], chs_mti[FPClusterIntrHart0Idx] };
 
 if (IslandsCfg.EnSpatzCluster) begin : gen_spatz_cluster
   spatz_cluster_wrapper #(

--- a/hw/carfield.sv
+++ b/hw/carfield.sv
@@ -2079,6 +2079,11 @@ axi_err_slv #(
   .slv_resp_o ( axi_ethernet_rsp       )
 );
 
+assign car_eth_intr = '0;
+assign eth_md_o     = '0;
+assign eth_md_oe    = '0;
+assign eth_mdc_o    = '0;
+
 end
 
 // APB peripherals


### PR DESCRIPTION
* Tie unused signals when ethernet is disabled
* Fix connection for spatz timer interrupt