### PR TITLE
Bumping PULP cluster for code cleanup.

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -375,7 +375,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 4d1558ac660ad445f62ffe44415ca6efc4240cf6
+    revision: e363672d9913fa72bf6fe1e2fecc74049c107684
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -352,7 +352,7 @@ packages:
     - common_cells
     - common_verification
   opentitan:
-    revision: 2c2830c055198f75fcd193f0e6772f70c2e2b036
+    revision: 6965a9a1e958ac5ed9ca7ec3eac9f0cb3f710be9
     version: null
     source:
       Git: https://github.com/pulp-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,7 +17,7 @@ dependencies:
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: cc541a6cf5995eea29dd255db68fbe7d2cd10af6 } # branch: michaero/carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: e363672d9913fa72bf6fe1e2fecc74049c107684 } # branch: yt/rapidrecovery
-  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 2c2830c055198f75fcd193f0e6772f70c2e2b036 } # branch: carfield_soc
+  opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 6965a9a1e958ac5ed9ca7ec3eac9f0cb3f710be9 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.4                                } 
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: cc541a6cf5995eea29dd255db68fbe7d2cd10af6 } # branch: michaero/carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 4d1558ac660ad445f62ffe44415ca6efc4240cf6 } # branch: yt/rapidrecovery
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: e363672d9913fa72bf6fe1e2fecc74049c107684 } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 2c2830c055198f75fcd193f0e6772f70c2e2b036 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }


### PR DESCRIPTION
This PR is bumping PULP cluster for fixes to inconsistent rtl code.
The PULP cluster commit in this branch resulted in clean setup/hold timing reports with P&R closing at 500 MHz.