### PR TITLE
Update Integer cluster dependencies

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -7,7 +7,7 @@ overrides:
   axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , version: 0.8.2 }
   apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
   register_interface:   { git: "https://github.com/pulp-platform/register_interface.git"  , version: 0.4.1 }
-  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "f3b1bc9b2e816fe1b51147ceafa8955326d1b466" } # branch: yt/rapidrecovery
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "32023555679cfdb8a0a073ad4c17fc3a5d1ddea5" } # branch: yt/rapidrecovery
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
   idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.5.1                                  }

--- a/Bender.lock
+++ b/Bender.lock
@@ -375,7 +375,7 @@ packages:
     dependencies:
     - axi_slice
   pulp_cluster:
-    revision: 450eb8780a3fe62cac6bcb0b34542ede2bc7c3c0
+    revision: de93f2001ee0a6fca1dc11f6dd95119d8e6aadfb
     version: null
     source:
       Git: https://github.com/pulp-platform/pulp_cluster.git
@@ -416,7 +416,7 @@ packages:
     - hwpe-stream
     - tech_cells_generic
   redundancy_cells:
-    revision: f3b1bc9b2e816fe1b51147ceafa8955326d1b466
+    revision: 32023555679cfdb8a0a073ad4c17fc3a5d1ddea5
     version: null
     source:
       Git: https://github.com/pulp-platform/redundancy_cells.git
@@ -436,7 +436,7 @@ packages:
     - common_cells
     - common_verification
   riscv:
-    revision: 8d1fac5542625f30551f3bfd44f512e83c6a6a50
+    revision: a1dcae35edae6092ddbf92c424690cb903b678d5
     version: null
     source:
       Git: git@github.com:AlSaqr-platform/riscv_nn.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.4                                } 
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
   safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 00ad366cf8823fa4d482ee0cffc866bf61f6d783 } # branch: michaero/carfield
-  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 450eb8780a3fe62cac6bcb0b34542ede2bc7c3c0 } # branch: yt/rapidrecovery
+  pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: de93f2001ee0a6fca1dc11f6dd95119d8e6aadfb } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 4215f93b4fddbb6dcaea48a5a1dc71c2bdc38061 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }


### PR DESCRIPTION
Bumping:
* RISCY to backup PC coming directly from IF to make redundant grouping work with rapid recovery.
* Redundancy cells to backup IF PC when cores are in independent mode.
* PULP cluster accordingly with the above ones.