### PR TITLE
sw: Remove init function from timer test

### DIFF
--- a/sw/tests/bare-metal/hostd/system_timer_test.c
+++ b/sw/tests/bare-metal/hostd/system_timer_test.c
@@ -32,9 +32,6 @@
 
 int main(void) {
 
-    // Init the HW
-    car_init_start();
-
     // Reset system timer
     writed(1, CAR_SYSTEM_TIMER_BASE_ADDR + TIMER_RESET_LO_OFFSET);
 


### PR DESCRIPTION
* Periph domain always on, enabling other islands not needed