### PR TITLE
sw: Remove car_init from cache partitioning R/W test

### DIFF
--- a/sw/tests/bare-metal/hostd/cache_partitioning_basic.c
+++ b/sw/tests/bare-metal/hostd/cache_partitioning_basic.c
@@ -36,9 +36,6 @@ int main(void)
 {
     int err = 0;
 
-    // Init the HW
-    car_init_start();
-
     // Init UART
     uint32_t rtc_freq   = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
     uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);


### PR DESCRIPTION
* Not needed, since LLc is in the host domain (always-on)