### PR TITLE
Bender: Fix TCLS endianness in safety island

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -7,7 +7,7 @@ overrides:
   axi_riscv_atomics:    { git: https://github.com/pulp-platform/axi_riscv_atomics.git     , version: 0.8.2 }
   apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
   register_interface:   { git: "https://github.com/pulp-platform/register_interface.git"  , version: 0.4.1 }
-  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "32023555679cfdb8a0a073ad4c17fc3a5d1ddea5" } # branch: yt/rapidrecovery
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "5616a36f5e51d6f07f1c8bca15194077657e197d" } # branch: yt/rapidrecovery
   tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
   riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
   idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.5.1                                  }

--- a/Bender.lock
+++ b/Bender.lock
@@ -416,7 +416,7 @@ packages:
     - hwpe-stream
     - tech_cells_generic
   redundancy_cells:
-    revision: 32023555679cfdb8a0a073ad4c17fc3a5d1ddea5
+    revision: 5616a36f5e51d6f07f1c8bca15194077657e197d
     version: null
     source:
       Git: https://github.com/pulp-platform/redundancy_cells.git
@@ -452,7 +452,7 @@ packages:
     - common_cells
     - tech_cells_generic
   safety_island:
-    revision: 3e9d4882cafff3580af5130dd94fea91a5c28d9b
+    revision: d0771928a2b850272c7a3d1b2a4a767bfb7c30a9
     version: null
     source:
       Git: git@iis-git.ee.ethz.ch:carfield/safety-island.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ dependencies:
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 99b654154f3c60db08d33d07e0885b44b5d846c1 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   car_l2:             { git: git@iis-git.ee.ethz.ch:carfield/carfield_l2_mem.git,       rev: 0143fb296e3614adf8894ff7335cc3f9b92783bd } # branch: main
-  safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: 3e9d4882cafff3580af5130dd94fea91a5c28d9b } # branch: michaero/carfield
+  safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: d0771928a2b850272c7a3d1b2a4a767bfb7c30a9 } # branch: michaero/carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: de93f2001ee0a6fca1dc11f6dd95119d8e6aadfb } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }


### PR DESCRIPTION
* Bits tracking core errors were flipped in endianness, so that error counters index was not matching the corresponding core