### PR TITLE
bender: Point to open-source safety-island IP

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -65,10 +65,10 @@ packages:
     - axi
     - common_cells
   axi_obi:
-    revision: f8605eadbb15b8de7a0833843403e991be04a15b
+    revision: null
     version: null
     source:
-      Git: git@iis-git.ee.ethz.ch:carfield/axi_obi.git
+      Path: .bender/git/checkouts/safety_island-f408198401cf8b88/future/axi_obi
     dependencies:
     - axi
     - common_cells
@@ -452,10 +452,10 @@ packages:
     - common_cells
     - tech_cells_generic
   safety_island:
-    revision: d0771928a2b850272c7a3d1b2a4a767bfb7c30a9
+    revision: aaef55c798ab53560faaf451a86668fa1e6d0f3b
     version: null
     source:
-      Git: git@iis-git.ee.ethz.ch:carfield/safety-island.git
+      Git: https://github.com/pulp-platform/safety_island.git
     dependencies:
     - apb
     - axi

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,7 +15,7 @@ dependencies:
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 0c95210cf242c384fafe3019e84b8974c3ff1e92 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
-  safety_island:      { git: git@iis-git.ee.ethz.ch:carfield/safety-island.git,         rev: d0771928a2b850272c7a3d1b2a4a767bfb7c30a9 } # branch: michaero/carfield
+  safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: de93f2001ee0a6fca1dc11f6dd95119d8e6aadfb } # branch: yt/rapidrecovery
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9 } # branch: carfield_soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }


### PR DESCRIPTION
* Point to open source `safety-island`
* This completes the open-sourcing process

Fixes #238  
 