### PR TITLE
Fix Spatz python dependencies in Carfield top level

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -30,6 +30,8 @@ BENDER      ?= bender
 BENDER_ROOT ?= $(CAR_ROOT)/.bender
 BENDER_PATH ?= $(shell which $(BENDER))
 
+PYTHON      ?= python3
+
 # Include mandatory bender targets and defines for multiple targets (sim, fpga, synth)
 include $(CAR_ROOT)/bender-common.mk
 include $(CAR_ROOT)/bender-sim.mk

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -20,7 +20,7 @@ The project is structured as follows:
 To *build* Carfield, you will need:
 
 - GNU Make `>= 3.82`
-- Python `>= 3.9`
+- Python `>= 3.0`
 - Bender `>= 0.27.1`
 - RISCV GCC `>= 11.2.0`
 - Python packages in `requirements.txt`

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -20,7 +20,7 @@ The project is structured as follows:
 To *build* Carfield, you will need:
 
 - GNU Make `>= 3.82`
-- Python `>= 3.0`
+- Python `>= 3.6`
 - Bender `>= 0.27.1`
 - RISCV GCC `>= 11.2.0`
 - Python packages in `requirements.txt`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 hjson
+jsonref
+jsonschema
 Mako==1.1.6
 PyYAML==6.0
 pyelftools==0.29
 requests
-hjson
 mako
 pyyaml
 tabulate


### PR DESCRIPTION
Spatz hw generation python scripts rely on two additional dependencies (_jsonref_, _jsonschema_) not listed in [requirements.txt](https://github.com/pulp-platform/carfield/blob/main/requirements.txt).

Moreover, the Spatz makefile will default to python3.6 if the PYTHON variable is not set. Therefore, changed it in [carfield.mk](https://github.com/pulp-platform/carfield/blob/main/carfield.mk) to default to python3.

Finally, remove the duplicated _hjson_ dependency.