### PR TITLE
ci: Fix hash of CVA6 sdk

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -44,7 +44,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= cf13e1d
+CAR_NONFREE_COMMIT ?= acda49f
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC


### PR DESCRIPTION
The CVA6 sdk was before selected via branch, creating issues with newer versions
See [CI merge request](https://iis-git.ee.ethz.ch/carfield/carfield-nonfree/-/merge_requests/49)