### PR TITLE
Bump CLIC to cut critical path.

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -14,7 +14,7 @@ overrides:
   hier-icache:          { git: "https://github.com/pulp-platform/hier-icache.git"         , rev: a971e364bf8090cf77fafad995b480c1ac7ea4e0   }
   scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , rev: 74426dee36f28ae1c02f7635cf844a0156145320   }
   cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", rev: 89e1019d64a86425211be6200770576cbdf3e8b3   } # branch: assertion-fix
-  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7   } # branch: balasr/dev-2
+  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , rev: 40ae266dab5768f63ca8dabe70e7474feb403bab   } # branch: critical-path
   fpnew:                { git: "https://github.com/pulp-platform/cvfpu.git"               , rev: pulp-v0.1.3 }
   cv32e40p:             { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991   }
   axi_rt:               { git: "https://github.com/pulp-platform/axi_rt.git"              , version: =0.0.0-alpha.4                         }

--- a/Bender.lock
+++ b/Bender.lock
@@ -139,8 +139,8 @@ packages:
     - tagger
     - unbent
   clic:
-    revision: 0ff9f07e0a492bff046dfe24399b1e1e82d557b7
-    version: 3.0.0-for-carfield
+    revision: 40ae266dab5768f63ca8dabe70e7474feb403bab
+    version: null
     source:
       Git: https://github.com/pulp-platform/clic.git
     dependencies:


### PR DESCRIPTION
Fixing critical path in CLIC. Needs [#17](https://github.com/pulp-platform/clic/pull/17) before merging.