### PR TITLE
fpga: Update spatz hash to support FPGA

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -489,7 +489,7 @@ packages:
     - common_cells
     - register_interface
   spatz:
-    revision: 2191fce502191995c2c670f6edb84b9b8370de86
+    revision: b4e651b9e0b884e8119dbc970f84ebdb2dc25103
     version: null
     source:
       Git: https://github.com/pulp-platform/spatz.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -24,7 +24,7 @@ dependencies:
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: 1.0.2                                }
   apb_adv_timer:      { git: https://github.com/pulp-platform/apb_adv_timer.git,        version: 1.0.4                                }
   can_bus:            { git: git@github.com:AlSaqr-platform/can_bus.git,                rev: 0ec0bf8b7dab6d5e4b3f7ec58338a8efee066379 } # branch: pulp
-  spatz:              { git: https://github.com/pulp-platform/spatz.git,                rev: 2191fce502191995c2c670f6edb84b9b8370de86 } # branch: aottaviano/spatz-carfield
+  spatz:              { git: https://github.com/pulp-platform/spatz.git,                rev: b4e651b9e0b884e8119dbc970f84ebdb2dc25103 } # branch: aottaviano/spatz-carfield
   common_cells:       { git: https://github.com/pulp-platform/common_cells.git,         version: 1.31.1                               }
   pulp-ethernet:      { git: https://github.com/pulp-platform/pulp-ethernet.git,        rev: bdc8031ab270a49da28df269266ce9ab9a133636 } # branch: carfield
   riscv-dbg:          { git: https://github.com/pulp-platform/riscv-dbg.git,            version: =0.8.0                               }


### PR DESCRIPTION
Add Spatz FF-based vregfile when targeting FPGA https://github.com/pulp-platform/spatz/pull/17