### PR TITLE
Update hyperbus and de-duplicate HyperRAM model fetching

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -272,8 +272,8 @@ packages:
     dependencies:
     - tech_cells_generic
   hyperbus:
-    revision: f039e601c8b6590181734e6d26ff8b77aa380412
-    version: null
+    revision: 7c1db76788ef1db05d893fea2b9c1ceb30d3f081
+    version: 0.0.8
     source:
       Git: https://github.com/pulp-platform/hyperbus.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -93,7 +93,6 @@ sources:
 
   - target: test
     files:
-      - target/sim/src/hyp_vip/s27ks0641.v
       - target/sim/src/vip_carfield_soc.sv
       - target/sim/src/carfield_fix.sv
       - target/sim/src/carfield_tb.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.2                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 0c95210cf242c384fafe3019e84b8974c3ff1e92 } # branch: aottaviano/carfield
-  hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: f039e601c8b6590181734e6d26ff8b77aa380412 } # branch: chi/add_fsm_with_Tcsh
+  hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.8                                }
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         rev: 135d0883d82d58ac803725ef69b027c666df7115 } # branch: yt/rapidrecovery

--- a/bender-sim.mk
+++ b/bender-sim.mk
@@ -9,3 +9,4 @@
 sim_targs += -t sim
 sim_targs += -t test
 sim_targs += -t simulation
+sim_targs += -t hyper_test

--- a/carfield.mk
+++ b/carfield.mk
@@ -45,7 +45,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= e39aebd1
+CAR_NONFREE_COMMIT ?= 07e60bb
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -23,6 +23,7 @@ CAR_SW_DIR  := $(CAR_ROOT)/sw
 CAR_TGT_DIR := $(CAR_ROOT)/target/
 CAR_XIL_DIR := $(CAR_TGT_DIR)/xilinx
 CAR_SIM_DIR := $(CAR_TGT_DIR)/sim
+HYP_ROOT    := $(shell $(BENDER) path hyperbus)
 # Questasim
 CAR_VSIM_DIR := $(CAR_TGT_DIR)/sim/vsim
 

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -3,4 +3,4 @@ sim/vsim/compile.carfield_soc.tcl
 sim/vsim/transcript
 sim/vsim/work/
 sim/vsim/uart/
-sim/src/hyp_vip
+sim/models

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -10,21 +10,21 @@ QUESTA ?= questa-2023.4
 TBENCH ?= tb_carfield_soc
 
 ## Get HyperRAM verification IP (VIP) for simulation
-$(CAR_TGT_DIR)/sim/src/hyp_vip:
-	rm -rf $@
-	mkdir $@
-	rm -rf model_tmp && mkdir model_tmp
-	cd model_tmp; wget https://www.infineon.com/dgdl/Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68
-	cd model_tmp; mv 'Infineon-S27KL0641_S27KS0641_VERILOG-SimulationModels-v05_00-EN.zip?fileId=8ac78c8c7d0d8da4017d0f6349a14f68' model.zip
-	cd model_tmp; unzip model.zip
-	cd model_tmp; mv 'S27KL0641 S27KS0641' exe_folder
-	cd model_tmp/exe_folder; unzip S27ks0641.exe
-	cp model_tmp/exe_folder/S27ks0641/model/s27ks0641.v model_tmp/exe_folder/S27ks0641/model/s27ks0641_verilog.sdf $@
-	rm -rf model_tmp
+# Forward relevant Hyperbus targets
+$(HYP_ROOT)/models/s27ks0641/s27ks0641.v:
+	@echo "[PULP] Fetch Hyperbus model"
+	@$(MAKE) -C $(HYP_ROOT) models/s27ks0641 > /dev/null
+
+$(CAR_TGT_DIR)/sim/models/s27ks0641.sdf: $(HYP_ROOT)/models/s27ks0641/s27ks0641.v
+	mkdir -p $(dir $@)
+	cp $(HYP_ROOT)/models/s27ks0641/s27ks0641.sdf $@
+	sed -i "s|(INSTANCE dut)|(INSTANCE i_hyper)|g" $@
+	sed -i "s|(INSTANCE dut/|(INSTANCE |g" $@
 
 CAR_SIM_ALL += $(CHS_ROOT)/target/sim/models/s25fs512s.v
 CAR_SIM_ALL += $(CHS_ROOT)/target/sim/models/24FC1025.v
-CAR_SIM_ALL += $(CAR_TGT_DIR)/sim/src/hyp_vip
+CAR_SIM_ALL += $(HYP_ROOT)/models/s27ks0641/s27ks0641.v
+CAR_SIM_ALL += $(CAR_TGT_DIR)/sim/models/s27ks0641.sdf
 
 # Defines for hyperram model preload at time 0
 HYP_USER_PRELOAD      ?= 0

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -43,11 +43,11 @@ RUNTIME_DEFINES += +define+HYP1_PRELOAD_MEM_FILE=\"$(HYP1_PRELOAD_MEM_FILE)\"
 
 QUESTA_FLAGS := -permissive -suppress 3009 -suppress 8386 -error 7 +UVM_NO_RELNOTES
 ifdef DEBUG
-	VOPT_FLAGS := $(QUESTA_FLAGS) +acc
+	VOPT_FLAGS := $(QUESTA_FLAGS) +acc -sdf
 	VSIM_FLAGS := $(QUESTA_FLAGS)
 	RUN_AND_EXIT := log -r /*; run -all
 else
-	VOPT_FLAGS := $(QUESTA_FLAGS) -O5 +acc=p+$(TBENCH). +noacc=p+carfield.
+	VOPT_FLAGS := $(QUESTA_FLAGS) -O5 +acc=p+$(TBENCH). +noacc=p+carfield. -sdf
 	VSIM_FLAGS := $(QUESTA_FLAGS) -c
 	RUN_AND_EXIT := run -all; exit
 endif

--- a/target/sim/src/vip_carfield_soc.sv
+++ b/target/sim/src/vip_carfield_soc.sv
@@ -110,7 +110,7 @@ module vip_carfield_soc
      for (genvar l=0; l<HypNumChips; l++) begin : sdf_annotation
         initial begin
 `ifndef PATH_TO_HYP_SDF
-           automatic string sdf_file_path = "../src/hyp_vip/s27ks0641_verilog.sdf";
+           automatic string sdf_file_path = "../models/s27ks0641.sdf";
 `else
            automatic string sdf_file_path = `PATH_TO_HYP_SDF;
 `endif

--- a/target/sim/src/vip_carfield_soc.sv
+++ b/target/sim/src/vip_carfield_soc.sv
@@ -88,7 +88,7 @@ module vip_carfield_soc
         .UserPreload   ( HypUserPreload ),
         .mem_file_name ( HypUserPreloadMemFiles[i] ),
         .TimingModel ( "S27KS0641DPBHI020" )
-      ) dut (
+      ) i_hyper (
         .DQ7      ( pad_hyper_dq[i][7]  ),
         .DQ6      ( pad_hyper_dq[i][6]  ),
         .DQ5      ( pad_hyper_dq[i][5]  ),
@@ -114,7 +114,7 @@ module vip_carfield_soc
 `else
            automatic string sdf_file_path = `PATH_TO_HYP_SDF;
 `endif
-           $sdf_annotate(sdf_file_path, hyperrams[p].chips[l].dut);
+           $sdf_annotate(sdf_file_path, hyperrams[p].chips[l].i_hyper);
            $display("Mem (%d,%d)",p,l);
         end
     end


### PR DESCRIPTION
* Re-use existing code in hyperbus to fetch sv model of HyperRAM and SDF
* Fix download of Hyperbus models
* Add `-sdf` switch to `vopt` to inform the tool that a part of the design uses SDF
* Update SDF annotation in testbench following changes in HyperRAM instance model naming (from `dut` to `i_hyper`)