### PR TITLE
carfield.mk: Use venv by default

### DIFF
--- a/carfield.mk
+++ b/carfield.mk
@@ -21,6 +21,7 @@ VENVDIR?=$(WORKDIR)/.venv
 REQUIREMENTS_TXT?=$(wildcard requirements.txt)
 include $(CAR_ROOT)/utils/venv.mk
 
+export PATH := $(VENVDIR)/bin:$(PATH)
 export PYTHON=
 export PYTHON3=
 override PYTHON := $(CAR_ROOT)/$(VENV)/python3


### PR DESCRIPTION
* On some machines, python calls may still fail if reference to venv is not explicit in the path (see our internal CI: https://iis-git.ee.ethz.ch/github-mirror/carfield/-/pipelines/99676)