### PR TITLE
[DEPRECATED] treewide: Various fixes

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -480,8 +480,8 @@ packages:
     dependencies:
     - tech_cells_generic
   serial_link:
-    revision: 77bec1aebd92b2ebea9962814f2370d5d48390c3
-    version: 1.1.0
+    revision: 4024f01b1d67cdf1cf9486467d0f2e2f407aa372
+    version: null
     source:
       Git: https://github.com/pulp-platform/serial_link.git
     dependencies:

--- a/carfield.mk
+++ b/carfield.mk
@@ -57,7 +57,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@iis-git.ee.ethz.ch:carfield/carfield-nonfree.git
-CAR_NONFREE_COMMIT ?= 8a065c72
+CAR_NONFREE_COMMIT ?= 6f8608c1
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/sw/tests/bare-metal/safed/sw.mk
+++ b/sw/tests/bare-metal/safed/sw.mk
@@ -20,7 +20,9 @@ SAFED_BUILD_TARGETS := $(addsuffix /build,$(SAFED_TEST_DIRS))
 # file format, if any is required.
 $(SAFED_SW_DIR)/tests/%/build: $(SAFED_ROOT) | venv
 	# Compile
-	$(MAKE) -C $(SAFED_SW_DIR)/tests/$* all
+	$(MAKE) -C $(SAFED_SW_DIR)/tests/$* all || true
+	# Make sure we don't have intermediate files in case of errors
+	@if [ ! -f $@/$*/$* ]; then echo "Error: Did you source env/safed-env.sh?"; $(RM) -r $@; exit 1; fi
 
 # Convert compiled binaries to header files
 SAFED_HEADER_TARGETS := $(patsubst $(SAFED_SW_DIR)/tests/%, $(CAR_SW_DIR)/tests/bare-metal/safed/%.h, $(SAFED_TEST_DIRS))


### PR DESCRIPTION
ci: Add file logging

ci: Update serial link to use PYTHON environment variable

sw: Delete Safety Island sw build target if compilation failed

Updated serial_link to the new master commit: https://github.com/pulp-platform/serial_link/commit/4024f01b1d67cdf1cf9486467d0f2e2f407aa372
Updated nonfree to this PR: https://iis-git.ee.ethz.ch/carfield/carfield-nonfree/-/merge_requests/55