### PR TITLE
Bender: Point to `apb_uart` release `v0.2.3` 

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -14,12 +14,14 @@ packages:
     dependencies:
     - tech_cells_generic
   apb_uart:
-    revision: 6c7dde3d749ac8274377745c105da8c8b8cd27c6
-    version: 0.2.1
+    revision: 8182a85d234417db46fe833533f8536644d3bee3
+    version: 0.2.3
     source:
       Git: https://github.com/pulp-platform/apb_uart.git
     dependencies:
     - apb
+    - obi
+    - obi_peripherals
     - register_interface
   axi:
     revision: fccffb5953ec8564218ba05e20adbedec845e014
@@ -179,8 +181,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: 2bd027cb87eaa9bf7d17196ec5f69864b35b630f
-    version: 1.32.0
+    revision: 9afda9abb565971649c2aa0985639c096f351171
+    version: 1.38.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -346,13 +348,21 @@ packages:
     dependencies:
     - common_cells
   obi:
-    revision: d04f1706ba5b7731bbc0a3a085e725e29fcc5b8e
-    version: 0.1.1
+    revision: 0155fc34e900c7c884e081c0a1114a247937ff69
+    version: 0.1.7
     source:
       Git: https://github.com/pulp-platform/obi.git
     dependencies:
     - common_cells
     - common_verification
+  obi_peripherals:
+    revision: 079894a6cbd4e544c477643d184a4c340bd4e391
+    version: 0.1.1
+    source:
+      Git: https://github.com/pulp-platform/obi_peripherals.git
+    dependencies:
+    - common_cells
+    - obi
   opentitan:
     revision: 74e7d6ca17e6a46e727ae2ae11177611232eaeb9
     version: null
@@ -436,8 +446,8 @@ packages:
     - register_interface
     - tech_cells_generic
   register_interface:
-    revision: d7693be4aef1fc7e7eb2b00b41c42e87d959866c
-    version: 0.4.2
+    revision: 5daa85d164cf6b54ad061ea1e4c6f3624556e467
+    version: 0.4.5
     source:
       Git: https://github.com/pulp-platform/register_interface.git
     dependencies:


### PR DESCRIPTION
* Required to fix some licensing issue
* We add the new dependency to Bender.local too, as technically we should bump to this through Cheshire (coming soon)