### PR TITLE
Bender: Fix hyperbus broken model download

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -481,7 +481,7 @@ packages:
     - common_cells
     - tech_cells_generic
   safety_island:
-    revision: aaef55c798ab53560faaf451a86668fa1e6d0f3b
+    revision: ae2bfaa07c85de34a0f4f334f376f21f6884b77f
     version: null
     source:
       Git: https://github.com/pulp-platform/safety_island.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -287,8 +287,8 @@ packages:
     dependencies:
     - tech_cells_generic
   hyperbus:
-    revision: 2a14bd8f9a985b488ee23d240764f52f129f7729
-    version: 0.0.9
+    revision: 841deb9d821b63bf05a1c85d3a4746352a8bcae2
+    version: null
     source:
       Git: https://github.com/pulp-platform/hyperbus.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -16,7 +16,7 @@ dependencies:
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 0c95210cf242c384fafe3019e84b8974c3ff1e92 } # branch: aottaviano/carfield
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.9                                }
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
-  safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: aaef55c798ab53560faaf451a86668fa1e6d0f3b } # branch: carfield
+  safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: ae2bfaa07c85de34a0f4f334f376f21f6884b77f } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         version: 3.0.3                                }
   opentitan:          { git: https://github.com/pulp-platform/opentitan.git,            rev: 48595339c9bea8eddf7cc799bb74e6af5ec5d846 } # branch: carfield-soc
   mailbox_unit:       { git: git@github.com:pulp-platform/mailbox_unit.git,             version: 1.1.0                                }

--- a/Bender.yml
+++ b/Bender.yml
@@ -14,7 +14,7 @@ dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.2                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
   cheshire:           { git: https://github.com/pulp-platform/cheshire.git,             rev: 0c95210cf242c384fafe3019e84b8974c3ff1e92 } # branch: aottaviano/carfield
-  hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.9                                }
+  hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             rev: 841deb9d821b63bf05a1c85d3a4746352a8bcae2 } # branch: aottaviano/nonfree
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: ae2bfaa07c85de34a0f4f334f376f21f6884b77f } # branch: carfield
   pulp_cluster:       { git: https://github.com/pulp-platform/pulp_cluster.git,         version: 3.0.3                                }


### PR DESCRIPTION
* This fixes the broken hyperram model download of current carfield `main`
due to Infineon new SSO webpage
* Fix safety island commit after erroneous force-push; this fixes #309 